### PR TITLE
docs: security-exceptions.md を uuid@14.0.0 マージ後の状態に更新

### DIFF
--- a/docs/research/security-exceptions.md
+++ b/docs/research/security-exceptions.md
@@ -1,11 +1,11 @@
 # セキュリティ例外記録
 
-最終更新: 2026-04-23（grammy 移行後 — request chain 3 件を根本解消）  
+最終更新: 2026-04-23（uuid@14.0.0 Dependabot PR マージ後）  
 audit 実行時: `pnpm audit` (npm registry)
 
 ## 概要
 
-`pnpm.overrides` + `node-cron` 3→4 アップグレード + `grammy` 移行により 30 件 → 2 件に削減済み。  
+`pnpm.overrides` + `node-cron` 3→4 アップグレード + `grammy` 移行 + `uuid@14.0.0` アップグレードにより 30 件 → **1 件**に削減済み。  
 以下は技術的制約により現時点で修正不能な脆弱性の記録。
 
 ---
@@ -22,21 +22,7 @@ audit 実行時: `pnpm audit` (npm registry)
 | 依存パス | `packages/jimmy > @whiskeysockets/baileys@7.0.0-rc.9 > @whiskeysockets/libsignal-node > protobufjs@6.8.8` |
 | 修正不能の理由 | `@whiskeysockets/libsignal-node` が protobufjs 6.x API に依存しており、7.x への上書きは API 破壊となる。`@whiskeysockets/baileys` の上流で libsignal-node が更新されるまで対処不能。 |
 | 緩和策 | protobufjs@6.8.8 の使用は WhatsApp セッション処理の内部プロセスに限定。外部入力を直接渡す経路はない。 |
-| 解消条件 | `@whiskeysockets/baileys` が `@whiskeysockets/libsignal-node` の新版（protobufjs 7.x 以降対応）に更新された時点で `@whiskeysockets/baileys>protobufjs` override を削除し再テスト。 |
-
----
-
-### [moderate] uuid@11.1.0 — Buffer Bounds Check 欠落
-
-| 項目 | 内容 |
-|------|------|
-| CVE | GHSA-w5hq-g745-h8pq |
-| 深刻度 | moderate |
-| 修正バージョン | >=14.0.0 |
-| 依存パス | `packages/jimmy > uuid@11.1.0` |
-| 修正不能の理由 | 修正バージョンは uuid 14.x（メジャー番号、API 破壊的変更の可能性あり）。プロジェクト直接依存として uuid@11.x を使用中。node-telegram-bot-api 経由の旧パス（uuid@8.3.2）は grammy 移行で除去済み。 |
-| 緩和策 | uuid はセッション ID 生成に使用。外部からの `buf` パラメータ付き uuid 呼び出しは行っていない（CVE の攻撃条件に該当しない）。 |
-| 解消条件 | `uuid@14.x` に更新可能になった時点でアップグレードを検討。 |
+| 解消条件 | `@whiskeysockets/baileys` が `@whiskeysockets/libsignal-node` の新版（protobufjs 7.x 以降対応）に更新された時点で `@whiskeysockets/baileys>protobufjs` override を削除し再テスト。Issue #30 で監視中。 |
 
 ---
 
@@ -57,3 +43,4 @@ audit 実行時: `pnpm audit` (npm registry)
 | request>qs | 6.x古版 | ^6.14.1 | moderate |
 | node-cron | 3.0.3 | 4.2.1 | — (uuid 依存を完全除去) |
 | node-telegram-bot-api | 0.67.0 | 除去（grammy に移行） | — (request chain を完全除去) |
+| uuid | 11.1.0 | 14.0.0 | moderate (GHSA-w5hq-g745-h8pq) |


### PR DESCRIPTION
## 概要

Dependabot PR #33（uuid@11.1.0 → 14.0.0）マージ後のドキュメント更新。

## 変更内容

- uuid@11.1.0 例外セクションを削除（脆弱性解消済み）
- 概要を「30件 → 1件」に更新
- 修正済み脆弱性表に uuid@14.0.0 を追記
- 残存例外は protobufjs@6.8.8 のみ（Issue #30 で監視中）