### PR TITLE
chore: protobufjs@6.8.8 (critical) を override で解消 — 脆弱性ゼロ達成

### DIFF
--- a/docs/research/security-exceptions.md
+++ b/docs/research/security-exceptions.md
@@ -1,30 +1,16 @@
 # セキュリティ例外記録
 
-最終更新: 2026-04-23（uuid@14.0.0 Dependabot PR マージ後）  
+最終更新: 2026-04-23（protobufjs@6.8.8 override 解消 — **脆弱性ゼロ達成**）  
 audit 実行時: `pnpm audit` (npm registry)
 
 ## 概要
 
-`pnpm.overrides` + `node-cron` 3→4 アップグレード + `grammy` 移行 + `uuid@14.0.0` アップグレードにより 30 件 → **1 件**に削減済み。  
-以下は技術的制約により現時点で修正不能な脆弱性の記録。
-
----
+`pnpm.overrides` + `node-cron` 3→4 + `grammy` 移行 + `uuid@14.0.0` + `libsignal-node>protobufjs` override により **30 件 → 0 件**を達成。  
+現時点で修正不能な脆弱性はない。
 
 ## 例外一覧
 
-### [critical] protobufjs@6.8.8 — 任意コード実行
-
-| 項目 | 内容 |
-|------|------|
-| CVE | GHSA-f3wb-9pbb-3jjj |
-| 深刻度 | critical |
-| 修正バージョン | >=7.5.5 |
-| 依存パス | `packages/jimmy > @whiskeysockets/baileys@7.0.0-rc.9 > @whiskeysockets/libsignal-node > protobufjs@6.8.8` |
-| 修正不能の理由 | `@whiskeysockets/libsignal-node` が protobufjs 6.x API に依存しており、7.x への上書きは API 破壊となる。`@whiskeysockets/baileys` の上流で libsignal-node が更新されるまで対処不能。 |
-| 緩和策 | protobufjs@6.8.8 の使用は WhatsApp セッション処理の内部プロセスに限定。外部入力を直接渡す経路はない。 |
-| 解消条件 | `@whiskeysockets/baileys` が `@whiskeysockets/libsignal-node` の新版（protobufjs 7.x 以降対応）に更新された時点で `@whiskeysockets/baileys>protobufjs` override を削除し再テスト。Issue #30 で監視中。 |
-
----
+**(現在は例外なし)**
 
 ## 修正済み脆弱性（`pnpm.overrides` 適用）
 
@@ -44,3 +30,4 @@ audit 実行時: `pnpm audit` (npm registry)
 | node-cron | 3.0.3 | 4.2.1 | — (uuid 依存を完全除去) |
 | node-telegram-bot-api | 0.67.0 | 除去（grammy に移行） | — (request chain を完全除去) |
 | uuid | 11.1.0 | 14.0.0 | moderate (GHSA-w5hq-g745-h8pq) |
+| protobufjs (libsignal-node chain) | 6.8.8 | >=7.5.5 (override) | critical (GHSA-f3wb-9pbb-3jjj) |

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
       "next": "^15.5.15",
       "request>form-data": "^2.5.4",
       "request>qs": "^6.14.1",
-      "@whiskeysockets/baileys>protobufjs": ">=7.5.5"
+      "@whiskeysockets/baileys>protobufjs": ">=7.5.5",
+      "@whiskeysockets/libsignal-node>protobufjs": ">=7.5.5"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   request>form-data: ^2.5.4
   request>qs: ^6.14.1
   '@whiskeysockets/baileys>protobufjs': '>=7.5.5'
+  '@whiskeysockets/libsignal-node>protobufjs': '>=7.5.5'
 
 importers:
 
@@ -1740,14 +1741,8 @@ packages:
   '@types/jsonwebtoken@9.0.10':
     resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
 
-  '@types/long@4.0.2':
-    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
-
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
-
-  '@types/node@10.17.60':
-    resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==}
 
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
@@ -2626,9 +2621,6 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
-  long@4.0.0:
-    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
-
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
@@ -2896,10 +2888,6 @@ packages:
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
-
-  protobufjs@6.8.8:
-    resolution: {integrity: sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==}
-    hasBin: true
 
   protobufjs@8.0.1:
     resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
@@ -5000,11 +4988,7 @@ snapshots:
       '@types/ms': 2.1.0
       '@types/node': 22.19.15
 
-  '@types/long@4.0.2': {}
-
   '@types/ms@2.1.0': {}
-
-  '@types/node@10.17.60': {}
 
   '@types/node@22.19.15':
     dependencies:
@@ -5116,7 +5100,7 @@ snapshots:
   '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
     dependencies:
       curve25519-js: 0.0.4
-      protobufjs: 6.8.8
+      protobufjs: 8.0.1
 
   '@xyflow/react@12.10.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -5896,8 +5880,6 @@ snapshots:
 
   lodash@4.18.1: {}
 
-  long@4.0.0: {}
-
   long@5.3.2: {}
 
   lru-cache@11.2.7: {}
@@ -6142,22 +6124,6 @@ snapshots:
       react-is: 17.0.2
 
   process-warning@5.0.0: {}
-
-  protobufjs@6.8.8:
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
-      '@types/long': 4.0.2
-      '@types/node': 10.17.60
-      long: 4.0.0
 
   protobufjs@8.0.1:
     dependencies:


### PR DESCRIPTION
## 概要

@whiskeysockets/libsignal-node の protobufjs@6.8.8 (critical) を pnpm override で解消。
**pnpm audit: 0 vulnerabilities found** — 30件から始まった脆弱性がゼロに。

## 修正内容

`pnpm.overrides` に以下を追加:
```json
"@whiskeysockets/libsignal-node>protobufjs": ">=7.5.5"
```

## 成立する理由

libsignal-node は `require("protobufjs/minimal")` のみ使用。  
`protobufjs/minimal` の API（`util.newBuffer`, `util.base64`, `util.ProtocolError`）は 6.x → 7.x で互換性があるため override が安全に機能した。

## テスト結果

- `pnpm audit`: 0 vulnerabilities ✅
- `pnpm test`: 278 tests PASS ✅
- `pnpm typecheck`: clean ✅
- `pnpm biome check`: 0 errors ✅

Related #30