### PR TITLE
chore: Biome 警告・エラー全解消（format / organizeImports / useTemplate）

### DIFF
--- a/packages/jimmy/src/connectors/cron/__tests__/connector.test.ts
+++ b/packages/jimmy/src/connectors/cron/__tests__/connector.test.ts
@@ -131,7 +131,10 @@ describe("AC-E003-03: CronConnector", () => {
       const connectors = makeConnectorMap("slack", {
         editMessage: mockEdit,
         getCapabilities: () => ({
-          threading: false, messageEdits: false, reactions: false, attachments: false,
+          threading: false,
+          messageEdits: false,
+          reactions: false,
+          attachments: false,
         }),
       });
       const c = new CronConnector(connectors, { connector: "slack", channel: "#g" });
@@ -144,7 +147,10 @@ describe("AC-E003-03: CronConnector", () => {
       const connectors = makeConnectorMap("slack", {
         editMessage: mockEdit,
         getCapabilities: () => ({
-          threading: false, messageEdits: true, reactions: false, attachments: false,
+          threading: false,
+          messageEdits: true,
+          reactions: false,
+          attachments: false,
         }),
       });
       const c = new CronConnector(connectors, { connector: "slack", channel: "#g" });

--- a/packages/jimmy/src/connectors/whatsapp/__tests__/format.test.ts
+++ b/packages/jimmy/src/connectors/whatsapp/__tests__/format.test.ts
@@ -94,7 +94,7 @@ describe("formatResponse", () => {
   it("splits text longer than 4000 chars into multiple chunks", () => {
     // Create text with newlines to allow splitting at word boundaries
     const line = "hello world ".repeat(40); // ~480 chars per line
-    const text = (line + "\n").repeat(10); // ~4810 chars
+    const text = `${line}\n`.repeat(10); // ~4810 chars
     const chunks = formatResponse(text);
     expect(chunks.length).toBeGreaterThan(1);
     // All characters should be preserved (accounting for trimStart)
@@ -105,7 +105,7 @@ describe("formatResponse", () => {
 
   it("splits at newline boundaries when possible", () => {
     // line is 50 chars, we need > 4000 chars total, so 90 lines
-    const line = "a".repeat(44) + " end";
+    const line = `${"a".repeat(44)} end`;
     const longText = Array.from({ length: 90 }, () => line).join("\n");
     const chunks = formatResponse(longText);
     expect(chunks.length).toBeGreaterThan(1);

--- a/packages/jimmy/src/cron/__tests__/runner.test.ts
+++ b/packages/jimmy/src/cron/__tests__/runner.test.ts
@@ -27,8 +27,8 @@ vi.mock("../../shared/logger.js", () => ({
   },
 }));
 
-import { appendRunLog } from "../jobs.js";
 import { findEmployee, scanOrg } from "../../gateway/org.js";
+import { appendRunLog } from "../jobs.js";
 import { runCronJob } from "../runner.js";
 
 // SessionManager の最小限モック

--- a/packages/jimmy/src/engines/__tests__/gemini.test.ts
+++ b/packages/jimmy/src/engines/__tests__/gemini.test.ts
@@ -613,8 +613,10 @@ describe("GeminiEngine", () => {
       proc.stdout.emit(
         "data",
         Buffer.from(
-          JSON.stringify({ type: "session.start", session_id: "gem-captured" }) + "\n" +
-          JSON.stringify({ type: "text", text: "partial answer" }) + "\n",
+          JSON.stringify({ type: "session.start", session_id: "gem-captured" }) +
+            "\n" +
+            JSON.stringify({ type: "text", text: "partial answer" }) +
+            "\n",
         ),
       );
       // 非ゼロ終了 → code !== 0 だが geminiSessionId があるので resolve

--- a/packages/jimmy/src/engines/__tests__/mock.test.ts
+++ b/packages/jimmy/src/engines/__tests__/mock.test.ts
@@ -129,9 +129,7 @@ describe("AC-E003-04: MockEngine", () => {
       await vi.runAllTimersAsync();
       const result = await p;
       // UUID v4 format: xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx
-      expect(result.sessionId).toMatch(
-        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-      );
+      expect(result.sessionId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
     });
 
     it("prefers resumeSessionId over sessionId", async () => {

--- a/packages/jimmy/src/gateway/__tests__/budgets.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/budgets.test.ts
@@ -8,13 +8,7 @@ const tmpHome = path.join(os.tmpdir(), `jinn-budgets-test-${process.pid}`);
 mkdirSync(path.join(tmpHome, "sessions"), { recursive: true });
 process.env.JINN_HOME = tmpHome;
 
-import {
-  checkBudget,
-  getBudgetEvents,
-  getBudgetStatus,
-  overrideBudget,
-  recordBudgetEvent,
-} from "../budgets.js";
+import { checkBudget, getBudgetEvents, getBudgetStatus, overrideBudget, recordBudgetEvent } from "../budgets.js";
 
 describe("AC-E003-04: getBudgetStatus", () => {
   it("returns ok with zero spend when employee has no budget config", () => {

--- a/packages/jimmy/src/gateway/__tests__/org.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/org.test.ts
@@ -21,8 +21,8 @@ vi.mock("../../shared/logger.js", () => ({
   },
 }));
 
-import { extractMention, extractMentions, findEmployee, scanOrg, updateEmployeeYaml } from "../org.js";
 import type { Employee } from "../../shared/types.js";
+import { extractMention, extractMentions, findEmployee, scanOrg, updateEmployeeYaml } from "../org.js";
 
 function writeYaml(subdir: string, filename: string, content: string) {
   const dir = path.join(tmpDir, subdir);

--- a/packages/jimmy/src/sessions/__tests__/callbacks.test.ts
+++ b/packages/jimmy/src/sessions/__tests__/callbacks.test.ts
@@ -19,7 +19,7 @@ vi.mock("../../shared/logger.js", () => ({
 }));
 
 import type { Session } from "../../shared/types.js";
-import { notifyDiscordChannel, notifyParentSession, notifyRateLimitResumed, notifyRateLimited } from "../callbacks.js";
+import { notifyDiscordChannel, notifyParentSession, notifyRateLimited, notifyRateLimitResumed } from "../callbacks.js";
 import { getSession } from "../registry.js";
 
 function makeSession(_overrides: Partial<Session> = {}): Session {
@@ -234,7 +234,7 @@ describe("notifyRateLimited — fire-and-forget", () => {
     await new Promise((r) => setTimeout(r, WAIT));
     // _sendRaw is called directly — it posts to the parent session endpoint
     const calls = fetchSpy.mock.calls.filter((args: unknown[]) =>
-      (args[0] as string).includes("/api/sessions/parent-001/message")
+      (args[0] as string).includes("/api/sessions/parent-001/message"),
     );
     expect(calls.length).toBeGreaterThanOrEqual(1);
     const body = JSON.parse(calls[calls.length - 1][1].body);
@@ -246,7 +246,7 @@ describe("notifyRateLimited — fire-and-forget", () => {
     notifyRateLimited(child, "2025-04-23T20:00:00Z");
     await new Promise((r) => setTimeout(r, WAIT));
     const calls = fetchSpy.mock.calls.filter((args: unknown[]) =>
-      (args[0] as string).includes("/api/sessions/parent-001/message")
+      (args[0] as string).includes("/api/sessions/parent-001/message"),
     );
     expect(calls.length).toBeGreaterThanOrEqual(1);
     const body = JSON.parse(calls[calls.length - 1][1].body);
@@ -284,7 +284,7 @@ describe("notifyRateLimitResumed — fire-and-forget", () => {
     notifyRateLimitResumed(child);
     await new Promise((r) => setTimeout(r, WAIT));
     const calls = fetchSpy.mock.calls.filter((args: unknown[]) =>
-      (args[0] as string).includes("/api/sessions/parent-001/message")
+      (args[0] as string).includes("/api/sessions/parent-001/message"),
     );
     expect(calls.length).toBeGreaterThanOrEqual(1);
     const body = JSON.parse(calls[calls.length - 1][1].body);
@@ -301,7 +301,7 @@ describe("notifyRateLimitResumed — fire-and-forget", () => {
     notifyRateLimitResumed(child);
     await new Promise((r) => setTimeout(r, WAIT));
     const calls = fetchSpy.mock.calls.filter((args: unknown[]) =>
-      (args[0] as string).includes("/api/sessions/parent-001/message")
+      (args[0] as string).includes("/api/sessions/parent-001/message"),
     );
     expect(calls.length).toBeGreaterThanOrEqual(1);
     const body = JSON.parse(calls[calls.length - 1][1].body);

--- a/packages/jimmy/src/sessions/__tests__/registry-ops.test.ts
+++ b/packages/jimmy/src/sessions/__tests__/registry-ops.test.ts
@@ -58,8 +58,8 @@ import {
   listSessions,
   markQueueItemCompleted,
   markQueueItemRunning,
-  recoverStaleSessions,
   recoverStaleQueueItems,
+  recoverStaleSessions,
   updateSession,
 } from "../registry.js";
 

--- a/packages/jimmy/src/shared/__tests__/effort.test.ts
+++ b/packages/jimmy/src/shared/__tests__/effort.test.ts
@@ -39,64 +39,39 @@ describe("AC-E003-03: resolveEffort", () => {
 
   describe("child session — resolution chain", () => {
     it("prefers childEffortOverride over everything else", () => {
-      const result = resolveEffort(
-        { effortLevel: "high", childEffortOverride: "low" },
-        childSession("medium"),
-        { effortLevel: "high" },
-      );
+      const result = resolveEffort({ effortLevel: "high", childEffortOverride: "low" }, childSession("medium"), {
+        effortLevel: "high",
+      });
       expect(result).toBe("low");
     });
 
     it("ignores invalid childEffortOverride and falls back to session.effortLevel", () => {
-      const result = resolveEffort(
-        { childEffortOverride: "turbo" },
-        childSession("medium"),
-      );
+      const result = resolveEffort({ childEffortOverride: "turbo" }, childSession("medium"));
       expect(result).toBe("medium");
     });
 
     it("uses session.effortLevel when no childEffortOverride", () => {
-      const result = resolveEffort(
-        { effortLevel: "high" },
-        childSession("low"),
-        { effortLevel: "medium" },
-      );
+      const result = resolveEffort({ effortLevel: "high" }, childSession("low"), { effortLevel: "medium" });
       expect(result).toBe("low");
     });
 
     it("ignores invalid session.effortLevel and falls through to employee default", () => {
-      const result = resolveEffort(
-        {},
-        childSession("turbo"),
-        { effortLevel: "low" },
-      );
+      const result = resolveEffort({}, childSession("turbo"), { effortLevel: "low" });
       expect(result).toBe("low");
     });
 
     it("uses employee.effortLevel when session has no valid effortLevel", () => {
-      const result = resolveEffort(
-        { effortLevel: "high" },
-        childSession(null),
-        { effortLevel: "low" },
-      );
+      const result = resolveEffort({ effortLevel: "high" }, childSession(null), { effortLevel: "low" });
       expect(result).toBe("low");
     });
 
     it("ignores invalid employee.effortLevel and falls through to engine default", () => {
-      const result = resolveEffort(
-        { effortLevel: "medium" },
-        childSession(null),
-        { effortLevel: "super" },
-      );
+      const result = resolveEffort({ effortLevel: "medium" }, childSession(null), { effortLevel: "super" });
       expect(result).toBe("medium");
     });
 
     it("falls through all layers and returns engine effortLevel for child sessions", () => {
-      const result = resolveEffort(
-        { effortLevel: "low" },
-        childSession(null),
-        null,
-      );
+      const result = resolveEffort({ effortLevel: "low" }, childSession(null), null);
       expect(result).toBe("low");
     });
 

--- a/packages/jimmy/src/shared/__tests__/version.test.ts
+++ b/packages/jimmy/src/shared/__tests__/version.test.ts
@@ -18,7 +18,7 @@ vi.mock("../paths.js", () => ({
   },
 }));
 
-import { compareSemver, getInstanceVersion, getPendingMigrations, getPackageVersion } from "../version.js";
+import { compareSemver, getInstanceVersion, getPackageVersion, getPendingMigrations } from "../version.js";
 
 // ── compareSemver（純粋関数） ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## 概要

ES-003 で追加したテストファイルに残っていた Biome lint/format 違反を全解消する。
CI 品質ゲート（E3）着手の前提として Biome クリーン状態を確立する。

## 変更内容

| 種別 | 件数 | 修正方法 |
|------|------|---------|
| `format` | 6件 | `pnpm biome check --write` で自動修正 |
| `assist/source/organizeImports` | 5件 | 同上（import 並び順を自動ソート） |
| `lint/style/useTemplate` | 2件 | 文字列結合 `+` → テンプレートリテラルに手動修正 |

**対象ファイル（全てテストファイル）:**
- `connectors/cron/__tests__/connector.test.ts`
- `connectors/whatsapp/__tests__/format.test.ts`
- `cron/__tests__/runner.test.ts`
- `engines/__tests__/gemini.test.ts` / `mock.test.ts`
- `gateway/__tests__/budgets.test.ts` / `org.test.ts`
- `sessions/__tests__/callbacks.test.ts` / `registry-ops.test.ts`
- `shared/__tests__/effort.test.ts` / `version.test.ts`

## 関連 Issue

Closes #58

## チェックリスト

- [x] `pnpm biome check`: 0 errors, 0 warnings
- [x] `pnpm test`: 524 passed
- [x] `pnpm build`: successful
- [x] 本番コード変更なし（テストファイルのみ）