### PR TITLE
feat(ES-005): E4 lefthook 整備（pre-commit lint / pre-push test / commit-msg）

### DIFF
--- a/docs/requirements/ES-005-lefthook-setup.md
+++ b/docs/requirements/ES-005-lefthook-setup.md
@@ -1,0 +1,53 @@
+<!-- 配置先: docs/requirements/ES-005-lefthook-setup.md -->
+# ES-005: E4 — lefthook 整備
+
+| 項目 | 内容 |
+|------|------|
+| ステータス | 承認済み |
+| 日付 | 2026-04-24 |
+| 対応 Issue | #62 |
+| 対応ストーリー | S10 |
+| Phase 定義書 | docs/requirements/PD-001-code-quality-stabilization.md |
+
+## 概要
+
+lefthook の pre-commit・commit-msg フック設定を確認・補完し、ローカルでの品質チェックを自動化する。
+
+## 現状
+
+| フック | 現状 | 問題 |
+|--------|------|------|
+| pre-commit | typecheck + actionlint | `pnpm lint`（biome check）が欠落 |
+| pre-push | build のみ | `pnpm test` がコメントアウト |
+| commit-msg | 未設定 | Conventional Commits 検証なし |
+
+## Acceptance Criteria
+
+| # | AC | 検証方法 |
+|---|-----|---------|
+| AC-1 | pre-commit に `pnpm lint` を追加し、biome 違反でコミットを阻止する | 意図的に lint エラーを入れてコミットが阻止されることを確認 |
+| AC-2 | pre-push の `pnpm test` コメントアウトを有効化する | `git push` 実行時にテストが走ることを確認 |
+| AC-3 | commit-msg フックで `<type>(<scope>): <subject>` 形式を検証する | 不正なメッセージでコミットが阻止されることを確認 |
+| AC-4 | `lefthook install` を実行してフックが動作する | フック実行ログを確認 |
+
+## 設計
+
+### commit-msg フック
+
+commitlint（外部ライブラリ）は追加しない。lefthook の `run` でシェルスクリプトとして実装する。
+
+検証対象フォーマット:
+```
+<type>(<scope>): <subject>
+<type>: <subject>
+```
+
+許可 type: `feat|fix|chore|docs|refactor|test|style|ci|perf|revert`
+
+### タスク分解
+
+| Task | 内容 | コミット |
+|------|------|---------|
+| TASK-014 | pre-commit に `pnpm lint` を追加 | `chore(lefthook): add biome lint to pre-commit hook` |
+| TASK-015 | pre-push の `pnpm test` を有効化 | `chore(lefthook): enable unit tests in pre-push hook` |
+| TASK-016 | commit-msg フック追加（Conventional Commits） | `chore(lefthook): add commit-msg hook for Conventional Commits` |

--- a/docs/requirements/PD-001-code-quality-stabilization.md
+++ b/docs/requirements/PD-001-code-quality-stabilization.md
@@ -97,7 +97,7 @@ jinn v0.9.3 をベースにした unstopia-gateway は、独自拡張（Antigrav
 | E2 | テストカバレッジ基盤 | S6, S7 | — | MUST | Vitest にカバレッジ計測（@vitest/coverage-v8）を追加し、E2E テストとの整合を確認する | docs/requirements/ES-002-test-coverage-foundation.md |
 | E2.5 | テストカバレッジ拡充 | S13, S14 | — | MUST | `packages/jimmy` のユニットテストを拡充し branch カバレッジを段階的に引き上げる。必要に応じてテスタビリティ改善リファクタリングを実施 | docs/requirements/ES-003-test-coverage-improvement.md |
 | E3 | CI 品質ゲート | S8, S9 | — | MUST | GitHub Actions ワークフローに biome check・カバレッジ閾値（branch 60%）・E2E テストを統合する | — |
-| E4 | lefthook 整備 | S10 | — | SHOULD | lefthook の pre-commit・commit-msg フック設定を確認・補完し、ローカルでの品質チェックを自動化する | — |
+| E4 | lefthook 整備 | S10 | — | SHOULD | lefthook の pre-commit・commit-msg フック設定を確認・補完し、ローカルでの品質チェックを自動化する | docs/requirements/ES-005-lefthook-setup.md |
 | E5 | ドキュメント整備 | S12 | — | COULD | `CONTRIBUTING.md` 新規作成（ブランチ命名・PR フロー・コミット規約・aidd-fw パイプライン記載）+ src/ 配下のモジュール依存関係箇条書き（`docs/architecture/module-dependencies.md`）| — |
 
 ## 8. Epic 間依存関係

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -6,6 +6,11 @@
 pre-commit:
   parallel: true
   jobs:
+    - name: lint
+      glob: "*.{ts,tsx,js,jsx,json}"
+      run: pnpm lint
+      stage_fixed: false
+
     - name: typecheck
       glob: "*.ts"
       run: pnpm typecheck

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -27,3 +27,16 @@ pre-push:
 
     - name: unit-tests
       run: pnpm test
+
+commit-msg:
+  jobs:
+    - name: conventional-commits
+      run: |
+        MSG=$(cat "{1}")
+        if ! echo "$MSG" | grep -qE "^(feat|fix|chore|docs|refactor|test|style|ci|perf|revert)(\(.+\))?: .+"; then
+          echo "Error: コミットメッセージが Conventional Commits 形式に準拠していません。"
+          echo "  正しい形式: <type>(<scope>): <subject>"
+          echo "  例: feat(engine): add Antigravity adapter"
+          echo "  使用可能な type: feat, fix, chore, docs, refactor, test, style, ci, perf, revert"
+          exit 1
+        fi

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,12 +7,12 @@ pre-commit:
   parallel: true
   jobs:
     - name: lint
-      glob: "*.{ts,tsx,js,jsx,json}"
+      glob: "**/*.{ts,tsx,js,jsx,json}"
       run: pnpm lint
       stage_fixed: false
 
     - name: typecheck
-      glob: "*.ts"
+      glob: "**/*.ts"
       run: pnpm typecheck
       stage_fixed: false
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -24,6 +24,6 @@ pre-push:
   jobs:
     - name: build
       run: pnpm build
-    # unit-tests: 既存の better-sqlite3 ネイティブモジュールエラー修正後に有効化
-    # - name: unit-tests
-    #   run: pnpm test
+
+    - name: unit-tests
+      run: pnpm test


### PR DESCRIPTION
## 概要

E4: lefthook の pre-commit・commit-msg フック設定を補完し、ローカルでの品質チェックを自動化する。

## 変更内容

### lefthook.yml

| フック | 変更前 | 変更後 |
|--------|--------|--------|
| pre-commit | typecheck + actionlint | **lint（biome check）** + typecheck + actionlint |
| pre-push | build のみ | build + **unit-tests（有効化）** |
| commit-msg | 未設定 | **Conventional Commits 検証（シェルスクリプト）** |

glob パターンも `*.ts` → `**/*.ts` に修正（サブディレクトリ対応）。

### docs/requirements/ES-005-lefthook-setup.md

ES-005 Epic 仕様書を新規作成。

## AC チェックリスト

- [x] pre-commit に `pnpm lint` を追加し、lint 違反でコミットを阻止する
- [x] pre-push の `pnpm test` コメントアウトを有効化する（524 tests passed）
- [x] commit-msg フックで Conventional Commits 形式を検証する（シェル正規表現）
- [x] `lefthook install` 実行済み・フック動作確認済み（pre-push: build ✔️ unit-tests ✔️）

## コミット履歴

- `chore(lefthook): add biome lint to pre-commit hook` (TASK-014)
- `chore(lefthook): enable unit tests in pre-push hook` (TASK-015)
- `chore(lefthook): add commit-msg hook for Conventional Commits` (TASK-016)
- `fix(lefthook): fix glob patterns to match subdirectory files`

Closes #62
Closes #63
Closes #64
Closes #65