### PR TITLE
[WIP] feat: ES-007 テストカバレッジ改善 — エンジン child_process モック

### DIFF
--- a/docs/requirements/ES-007-engine-mocks.md
+++ b/docs/requirements/ES-007-engine-mocks.md
@@ -1,0 +1,157 @@
+<!-- 配置先: docs/requirements/ES-007-engine-mocks.md — 相対リンクはこの配置先を前提としている -->
+# ES-007: テストカバレッジ改善 — グループA（エンジン child_process モック）
+
+| 項目 | 内容 |
+|------|------|
+| 例外承認 Issue | — |
+| Issue | #74 |
+| Phase 定義書 | PD-002 |
+| Epic | E7（テスト拡充 — engines サブグループ） |
+| 所属 BC | — （テスト追加のみ。ドメインモデルなし） |
+| ADR 参照 | — （テスト方針は docs/conventions/testing.md に記載済み） |
+
+## 対応ストーリー
+
+<!-- Phase 定義書 PD-002 §3 から転記 -->
+
+- S10: As a **開発者**, I want to `engines/claude.ts`（89条件分岐）のストリーミング処理を状態機械に整理したい, so that デルタ処理の条件分岐が追跡しやすくなり、新エンジン追加時の参考実装になる.
+
+> **スコープ注記:** ES-007 は S10 の「リファクタリング」部分は対象外（後続 Epic で対応）。
+> `engines/claude.ts`・`engines/codex.ts` に `vi.mock("node:child_process")` パターンでテストを追加し、主要ロジックを先に検証可能にすることに集中する。
+> これにより、今後のリファクタリング（状態機械整理）を安全に進める土台を作る。
+> `engines/gemini.ts` は同手法で 86% カバレッジ達成済み（`engines/__tests__/gemini.test.ts` 参照）。
+
+## 概要
+
+`engines/claude.ts`（622行）・`engines/codex.ts`（391行）に `vi.mock("node:child_process")` パターンでテストを追加し、両エンジンの branch カバレッジを 70% 以上に引き上げる。`gemini.ts` と同じ `InterruptibleEngine` インターフェースを実装しているため、同一テストパターンが適用可能。
+
+現状（テスト追加前）0% → 目標 70%+。
+
+## ストーリーと受入基準
+
+### Story 1: `engines/claude.ts` のテスト追加
+
+> As a **開発者**, I want to `engines/claude.ts` に `vi.mock("node:child_process")` パターンでテストを追加したい, so that エンジンの主要ロジック（ストリーミング・ライフサイクル・エラー処理）が自動検証され、将来のリファクタリングを安全に行えるようになる.
+
+**受入基準:**
+
+- [ ] **AC-E007-01**: 開発者が `packages/jimmy` で `pnpm test` を実行すると、`engines/__tests__/claude.test.ts` が認識・実行され、identity / lifecycle / run（非ストリーミング） / run（引数構築） / run（エラーシナリオ） / run（ストリーミング） の全テストグループが PASS する。 ← S10
+- [ ] **AC-E007-02**: `vi.mock("node:child_process")` で spawn をモックした `claude.test.ts` が作成されており、`createMockProcess()` ヘルパーを使って EventEmitter ベースの擬似プロセスを生成し、stdout / stderr / close / error イベントを任意のタイミングで発行できる。 ← S10（AI 補完: テストインフラの構造を AC 化することでテスト方針を明確化）
+- [ ] **AC-E007-03**: `pnpm test --coverage` を実行すると `engines/claude.ts` の branch カバレッジが **70% 以上**になる。 ← S10
+
+**インターフェース:** `InterruptibleEngine` (`src/shared/types.ts`) — `run(opts: EngineRunOpts): Promise<EngineResult>` / `kill(sessionId: string)` / `isAlive(sessionId: string): boolean` / `killAll()`
+
+### Story 2: `engines/codex.ts` のテスト追加
+
+> As a **開発者**, I want to `engines/codex.ts` に同一パターンでテストを追加したい, so that claude.ts と同様に主要ロジックが自動検証され、2エンジンのテスト基盤が揃う.
+
+**受入基準:**
+
+- [ ] **AC-E007-04**: `engines/__tests__/codex.test.ts` が作成されており、identity / lifecycle / buildFreshArgs / buildResumeArgs / processJsonlLine / run（成功） / run（ストリーミング） / run（エラー）/ run（kill） の全テストグループが PASS する。 ← S10（AI 補完: codex の JSONL 解析ロジックは複数の分岐を持つため個別グループとして明示）
+- [ ] **AC-E007-05**: `pnpm test --coverage` を実行すると `engines/codex.ts` の branch カバレッジが **70% 以上**になる。 ← S10
+
+### Story 3: 既存テストへの非干渉
+
+> As a **開発者**, I want to 両エンジンのテスト追加後も既存テストが全 PASS することを確認したい, so that テスト追加がリグレッションを引き起こしていないことを担保できる.
+
+**受入基準:**
+
+- [ ] **AC-E007-06**: `pnpm test` を実行すると、`gemini.test.ts`・`mock.test.ts` 等の既存テストが全て引き続き PASS する。 ← S10（AI 補完: テスト追加時の副作用チェックは品質保証上必須）
+- [ ] **AC-E007-07**: `pnpm build` が PASS し、既存コードの構造（`engines/claude.ts`・`engines/codex.ts` の実装本体）が変更されていないことを確認できる。 ← S10（AI 補完: テスト追加でソースを変更しないことの検証）
+
+**インターフェース:** カバレッジレポート（HTML / テキスト出力）。外部 API なし。
+
+## 設計成果物
+
+<!-- テスト追加のみ Epic のため、ドメインモデル・DB スキーマ・API spec は該当なし -->
+
+| 成果物 | 配置先 | ステータス |
+|--------|--------|----------|
+| 集約モデル詳細 | — | 該当なし（ドメインモデルなし） |
+| DB スキーマ骨格 | — | 該当なし（データ永続化なし） |
+| API spec 骨格 | — | 該当なし（API 変更なし） |
+
+**スキップ理由:** ES-007 はテスト追加のみ。新しいドメイン概念・DB テーブル・API エンドポイントを導入しないため、Step 2-3 をスキップする。
+
+## バリデーションルール
+
+| フィールド | ルール | エラー時の振る舞い |
+|-----------|--------|------------------|
+| vi.mock のスコープ | `vi.mock("node:child_process")` はファイルの先頭で宣言し、ホイスティングにより全テストに適用される | ホイスティング順を誤るとモックが効かないため、import 順を調整する |
+| EventEmitter ベースのモック | `createMockProcess()` が stdout / stderr / EventEmitter を正しく持つこと | 必要プロパティが欠けていると型エラーまたはランタイムエラーが発生する |
+| カバレッジ閾値 | branch 70%（claude.ts・codex.ts それぞれ） | 閾値未達の場合は未カバーの条件分岐にテストを追加する |
+
+## ステータス遷移（該当なし）
+
+テスト追加のみ。エンティティのステータス遷移なし。
+
+## エラーケース
+
+| ケース | 条件 | 期待する振る舞い | 説明 |
+|--------|------|----------------|------|
+| spawn エラー | `proc.emit("error", new Error("ENOENT"))` | `engine.run()` が rejected または error を含む EngineResult を返す | claude.ts は spawn error を error EngineResult に変換する |
+| 非ゼロ終了コード | `proc.emit("close", 1)` | エラーメッセージを含む EngineResult が返る | exit code 非ゼロでも stdout JSON が有効な場合は JSON を優先する |
+| セッション kill 後の run | `engine.kill(sessionId)` 後に close | terminationReason を含む EngineResult が返る | kill フラグで正常終了と区別する |
+| JSON パース失敗 | stdout に不正 JSON | エラー EngineResult を返す（例外を投げない） | claude.ts は JSON parse 失敗をハンドルして error 扱いにする |
+| processJsonlLine 不明イベント | codex の JSONL に未知の type | null を返し無視する | codex.ts は未知イベントを安全に無視する設計 |
+
+## 非機能要件
+
+| 項目 | 基準 |
+|------|------|
+| テスト実行時間 | `pnpm test --coverage` が 120 秒以内に完了する |
+| テストの独立性 | `vi.clearAllMocks()` を `beforeEach` で呼び出し、各テストが独立して実行できる |
+| モック方針 | `vi.mock("node:child_process")` でグローバルモックを使用（`node:child_process` は引数注入が困難な外部 I/O のため例外的に許容。`docs/conventions/testing.md` の `suppress-approved: node:child_process グローバルモックは引数注入不可の OS 依存 I/O のため許容` に準拠） |
+| リファクタリング禁止 | `engines/claude.ts`・`engines/codex.ts` の実装本体を変更しない。テストコードのみ追加する |
+| 型安全 | `MockProcess` インターフェースを定義し `vi.mocked()` でモックの型付けを行う |
+
+## デリバリーする価値
+
+| 項目 | 内容 |
+|------|------|
+| 対象ユーザー/ペルソナ | 開発者（自分） |
+| デリバリーする価値 | `engines/claude.ts`・`engines/codex.ts` の branch カバレッジが 0% → 70%+ に向上し、両エンジンの主要ロジック（ライフサイクル・ストリーミング・エラー処理）が自動検証される。E6（engines/claude 整理）等の後続リファクタリングを安全に進める土台が整う。 |
+| デモシナリオ | 1. `packages/jimmy` で `pnpm test --coverage` を実行する → 2. `engines/claude.ts` の branch カバレッジが 70% 以上を示す → 3. `engines/codex.ts` の branch カバレッジが 70% 以上を示す → 4. 既存テスト（gemini.test.ts 等）が全 PASS することを確認する |
+
+## E2E 検証計画
+
+| 項目 | 内容 |
+|------|------|
+| 検証シナリオ | AC-E007-01〜07: `packages/jimmy` で `pnpm test --coverage` を実行し全テスト PASS + claude.ts・codex.ts の branch カバレッジ 70% 以上を確認（自動検証）。`pnpm build` が PASS することを確認（手動デモ）。 |
+| 検証環境 | ローカル開発環境（Node.js + pnpm）。外部サービス・gateway 起動は不要。`node:child_process` は vitest の `vi.mock` で完全モック。 |
+| 前提条件 | `pnpm install` 完了。`@vitest/coverage-v8` インストール済み（ES-002 で対応済み）。`engines/__tests__/gemini.test.ts` が参照実装として存在すること。 |
+
+## 他 Epic への依存・影響
+
+- **ES-003（テスト拡充基盤）に依存（完了済み）**: vitest 設定・`@vitest/coverage-v8` が整備されている前提
+- **ES-004（CI 品質ゲート）に依存（完了済み）**: CI でのカバレッジ閾値チェックが有効であることを前提
+- **E6（engines/claude 整理, S10）に依存される**: engines テスト（本 Epic）が揃ってからリファクタリングを安全に実施できる
+- **E7（テスト拡充 sessions）と並行可能**: sessions テストとは独立して実施可能
+- **PD-002 成功基準（branch カバレッジ 40%）に貢献**: engines の 0% → 70% は全体カバレッジ向上に直接貢献する
+
+## 未決定事項
+
+| # | 事項 | ステータス | 解決先 |
+|---|------|----------|--------|
+| 1 | `engines/claude.ts` の streaming モードでの詳細デルタ処理の AC 網羅範囲（content_block_delta / tool_use / tool_result / text_snapshot） | 確定: 実装済みテストで対象グループを明示（AC-E007-01 に含む） | — |
+| 2 | `vi.mock` グローバルモックの許容判断（testing.md の原則との兼ね合い） | 確定: `node:child_process` は引数注入不可な OS 依存 I/O のため例外的に許容（非機能要件に記載） | — |
+
+## 完全性チェック
+
+- [x] 全ストーリーに AC が定義されている（S1: AC-E007-01〜03、S2: AC-E007-04〜05、S3: AC-E007-06〜07）
+- [x] 正常系・異常系のレスポンスが定義されている（エラーケース: 5 件）
+- [x] バリデーションルールが網羅されている（vi.mock スコープ・EventEmitter 構造・カバレッジ閾値）
+- [x] ステータス遷移が図示されている（該当なし）
+- [x] 権限が各操作で明記されている（開発者のみ — ローカル操作）
+- [x] 関連 ADR が参照されている（ADR 不要。testing.md に方針記載済み）
+- [x] 非機能要件が定義されている（実行時間・独立性・モック方針・リファクタリング禁止・型安全）
+- [x] 他 Epic への依存・影響が明記されている（ES-003・ES-004・E6・E7・PD-002 成功基準）
+- [x] 未決定事項が明示されている（2 件、いずれも確定）
+- [x] デリバリーする価値が明記されている（対象ユーザー・価値・デモシナリオ）
+- [x] E2E 検証計画が定義されている（検証シナリオ・検証環境・前提条件）
+- [x] 全 AC に AC-ID（`AC-E007-NN` 形式）が付与されている
+- [x] 対応ストーリーが Phase 定義書から転記されている（S10）
+- [x] 全 AC にストーリートレース（`← Sn`）が付与されている
+- [x] AI 補完の AC には理由が明記されている（AC-E007-02、AC-E007-04、AC-E007-06、AC-E007-07）
+- [x] 所属 BC が記載されている（該当なし — ドメインモデルなし）
+- [x] 設計成果物セクションが記入されている（該当なし、スキップ理由記載）

--- a/docs/research/complexity-and-di-analysis.md
+++ b/docs/research/complexity-and-di-analysis.md
@@ -1,0 +1,206 @@
+# リサーチ: コードベース複雑度分析と DI 化方針
+
+| 項目 | 内容 |
+|------|------|
+| 調査日 | 2026-04-25 |
+| 調査目的 | リファクタリング・DI 化の優先ターゲットと実施方針を根拠付きで決定する |
+| リサーチ種別 | コードベース分析 + 技術選定 |
+| 依頼元 | ユーザー直接 |
+
+---
+
+## 1. 複雑度ランキング（本番コードのみ）
+
+計測指標: 行数 / import 数 / 条件分岐数（if・switch・else・case の合計）
+
+| 順位 | ファイル | 行数 | import 数 | 条件分岐数 | 複雑度評価 |
+|------|---------|------|-----------|-----------|-----------|
+| 🔴 1 | `gateway/api.ts` | 2668 | 26 | 310 | **最高** — 単一ファイルに全 API ルートが集中 |
+| 🔴 2 | `sessions/manager.ts` | 982 | 15 | 89 | **高** — DI の主要ターゲット |
+| 🔴 3 | `engines/claude.ts` | 622 | 4 | 89 | **高** — ストリーミング処理の条件分岐が多い |
+| 🟡 4 | `gateway/server.ts` | 779 | 27 | 76 | **中高** — import が最多、Composition Root 候補 |
+| 🟡 5 | `sessions/context.ts` | 825 | 6 | 59 | **中高** — 関数数 16、コンテキスト構築ロジックが密集 |
+| 🟡 6 | `sessions/registry.ts` | 698 | 7 | 25 | **中** — 関数数 33、SQLite 操作が集中 |
+| 🟢 7 | `mcp/gateway-server.ts` | 420 | 1 | — | **低** — import 少、機能集中 |
+| 🟢 8 | `cli/setup.ts` | 539 | 9 | — | **低中** — CLI コマンド、単体テスト容易 |
+
+---
+
+## 2. 循環依存の詳細マップ
+
+`import type` により TypeScript の型レベルでは緩和されているが、実行時の依存グラフとしては以下の3サイクルが存在する。
+
+### サイクル A: gateway ⟷ sessions（最重要）
+
+```
+gateway/server.ts
+  → sessions/manager.ts        ← SessionManager の生成・利用
+  → sessions/registry.ts       ← DB 操作
+
+sessions/manager.ts
+  → gateway/budgets.ts         ← セッション実行前の予算チェック
+```
+
+**問題:** `gateway/server.ts` が `SessionManager` を生成・管理しているが、`SessionManager` は予算チェックのために `gateway/budgets` を呼び出す。責務の境界が曖昧。
+
+### サイクル B: cron ⟷ sessions
+
+```
+cron/runner.ts
+  → sessions/manager.ts        ← SessionManager 型参照・呼び出し
+cron/scheduler.ts
+  → sessions/manager.ts        ← SessionManager 型参照
+
+sessions/manager.ts
+  → cron/jobs.ts               ← Cron ジョブ定義の参照
+  → cron/scheduler.ts          ← Cron スケジューラー操作
+```
+
+**問題:** Cron がセッションを開始し、セッションが Cron を操作する相互依存。
+
+### サイクル C: cron → gateway（一方向だが gateway のサイクルを増幅）
+
+```
+cron/runner.ts
+  → gateway/org.ts             ← 組織・従業員の検索
+```
+
+**問題:** Cron ジョブの実行時に「どの従業員に送るか」を解決するために `gateway/org` を参照。Cron が Gateway に依存している。
+
+### 依存グラフ全体
+
+```
+shared/  (基盤層 — 依存なし)
+  ↑
+engines/ ←── claude / codex / gemini / mock
+connectors/ ←── telegram / slack / discord / whatsapp / cron
+mcp/
+stt/
+  ↑
+cron/ ⟷ sessions/ ⟷ gateway/ ← cli/
+  ↑──────────────────┘
+       (3 サイクル)
+```
+
+---
+
+## 3. DI パターン選択肢の比較
+
+### 選択肢
+
+| 手法 | デコレータ要否 | ESM 互換 | 学習コスト | バンドル増加 | メンテナンス |
+|------|-------------|----------|-----------|-------------|------------|
+| **手動 DI** | 不要 | ✅ 完全 | 低 | ゼロ | 不要 |
+| **Awilix** | 不要 | ✅ 完全 | 中 | 小（~15KB） | 活発 |
+| **tsyringe** | 必要（`experimentalDecorators`） | ⚠️ 要確認 | 低中 | 中 | 安定 |
+| **InversifyJS** | 必要 | ⚠️ 要確認 | 中高 | 大 | 中程度 |
+| **Effect** | 不要 | ✅ 完全 | **高** | 大 | 活発 |
+
+### 本プロジェクトへの適合評価
+
+本プロジェクトは:
+- `experimentalDecorators` 未使用
+- ESM（`.js` 拡張子 import）
+- クラスベース（`SessionManager` 等）+ 関数ベース混在
+- モジュール数は ~10（大規模 DI フレームワーク不要）
+
+→ **デコレータ系（tsyringe / InversifyJS）は設定変更コストが高く不適**。Effect は既存設計との衝突が大きい。
+
+---
+
+## 4. 推薦アクション
+
+### フェーズ 1: 手動 DI の導入（低コスト・即効性高）
+
+**対象: `gateway/server.ts` を Composition Root に昇格**
+
+現状 `server.ts` でエンジン・コネクター・SessionManager を生成しているが、依存が散在している。明示的な Composition Root パターンを導入し、全依存を1箇所で組み立てる。
+
+```typescript
+// Before: server.ts で直接 new
+const manager = new SessionManager(config, engines, connectorNames);
+
+// After: composition-root.ts で一元管理
+function buildContainer(config: JinnConfig) {
+  const engines = buildEngines(config);
+  const connectors = buildConnectors(config);
+  const manager = new SessionManager(config, engines, connectors);
+  return { manager, engines, connectors };
+}
+```
+
+**効果:** 循環依存サイクル A（gateway ⟷ sessions）の起点を明確化。テストで差し替え可能に。
+
+### フェーズ 2: `gateway/api.ts` の分割（最優先・効果最大）
+
+2668 行・310 条件分岐は単一ファイルとして限界を超えている。以下の4ドメインに分割する:
+
+| 新ファイル | 担当 API |
+|---------|---------|
+| `gateway/api/sessions-api.ts` | セッション CRUD・実行・ストリーミング |
+| `gateway/api/org-api.ts` | 組織・従業員・部署管理 |
+| `gateway/api/files-api.ts` | ファイルアップロード・管理 |
+| `gateway/api/skills-api.ts` | スキル管理・検索 |
+
+**効果:** テスト容易性向上、PR レビュー負荷軽減、各 API の独立変更が可能に。
+
+### フェーズ 3: 循環依存の解消
+
+**サイクル A（gateway ⟷ sessions）解消方針:**
+
+`BudgetChecker` インターフェースを `shared/types.ts` に定義し、`sessions/manager.ts` は実装に依存しない:
+
+```typescript
+// shared/types.ts に追加
+export interface BudgetChecker {
+  checkBudget(employeeId: string, cost: number): Promise<boolean>;
+}
+
+// sessions/manager.ts — gateway への直接依存を除去
+constructor(config, engines, budgetChecker: BudgetChecker) { ... }
+
+// gateway/server.ts — 実装を注入
+const manager = new SessionManager(config, engines, new GatewayBudgetChecker(config));
+```
+
+**サイクル B（cron ⟷ sessions）解消方針:**
+
+`SessionRunner` インターフェースを分離し、Cron は SessionManager 本体ではなくインターフェースに依存:
+
+```typescript
+// shared/types.ts に追加
+export interface SessionRunner {
+  run(opts: SessionRunOpts): Promise<void>;
+}
+```
+
+### 優先順位まとめ
+
+| 優先度 | アクション | 工数感 | 効果 |
+|--------|---------|--------|------|
+| ⭐⭐⭐ | `gateway/api.ts` を4ファイルに分割 | 中 | 最大（可読性・テスト容易性） |
+| ⭐⭐⭐ | `gateway/server.ts` を Composition Root 化 | 小 | DI 基盤の確立 |
+| ⭐⭐ | サイクル A 解消（BudgetChecker インターフェース抽出） | 中 | 循環依存の根本解消 |
+| ⭐⭐ | `sessions/manager.ts` の責務分離（EngineRunner 抽出） | 中 | テスト容易性 |
+| ⭐ | Awilix 導入（モジュール数増加後） | 中 | DI 自動化 |
+
+---
+
+## 5. リスクと注意点
+
+| リスク | 内容 | 対策 |
+|--------|------|------|
+| リグレッション | `api.ts` 分割時の API 動作変更 | 分割前に統合テストを追加、段階的に移行 |
+| 循環依存の深さ | madge で検出できない動的 require | `npx madge --circular --extensions ts src/` で事前計測 |
+| テストカバレッジ低下 | リファクタリング後に閾値を下回る | 分割単位でカバレッジを計測しながら進める |
+| Awilix の ESM 互換 | Named exports との衝突 | `awilix` v10+ は ESM 対応済みを確認済み |
+
+---
+
+## ソース
+
+- [LogRocket: Top 5 TypeScript DI containers](https://blog.logrocket.com/top-five-typescript-dependency-injection-containers/) — 参照日: 2026-04-25
+- [npm-compare: awilix vs inversify vs tsyringe](https://npm-compare.com/awilix,inversify,tsyringe) — 参照日: 2026-04-25
+- [Awilix GitHub](https://github.com/jeffijoe/awilix) — 参照日: 2026-04-25
+- [Medium: Fixing Circular Dependencies in TypeScript](https://medium.com/visual-development/how-to-fix-nasty-circular-dependency-issues-once-and-for-all-in-javascript-typescript-a04c987cf0de) — 参照日: 2026-04-25
+- コードベース実測値（`wc -l`, `grep -c` による計測）— 2026-04-25

--- a/packages/jimmy/src/engines/__tests__/claude.test.ts
+++ b/packages/jimmy/src/engines/__tests__/claude.test.ts
@@ -1,0 +1,875 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EngineRunOpts, StreamDelta } from "../../shared/types.js";
+import { ClaudeEngine } from "../claude.js";
+
+// Mock child_process.spawn
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+import { spawn } from "node:child_process";
+
+const mockSpawn = vi.mocked(spawn);
+
+interface MockProcess {
+  emit: EventEmitter["emit"];
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  stdin: { end: ReturnType<typeof vi.fn> };
+  pid: number;
+  exitCode: number | null;
+  killed: boolean;
+  kill: ReturnType<typeof vi.fn>;
+}
+
+function createMockProcess(): MockProcess {
+  const emitter = new EventEmitter();
+  const proc: MockProcess = Object.assign(emitter, {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    stdin: { end: vi.fn() },
+    pid: 11111,
+    exitCode: null as number | null,
+    killed: false,
+    kill: vi.fn(() => {
+      proc.killed = true;
+      return true;
+    }),
+  });
+  return proc;
+}
+
+// Helper: simulate a successful non-streaming run
+async function runWithOutput(
+  engine: ClaudeEngine,
+  opts: EngineRunOpts,
+  outputLines: string[],
+  exitCode = 0,
+) {
+  const proc = createMockProcess();
+  mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+  const resultPromise = engine.run(opts);
+
+  for (const line of outputLines) {
+    proc.stdout.emit("data", Buffer.from(line));
+  }
+  proc.exitCode = exitCode;
+  proc.emit("close", exitCode);
+
+  return resultPromise;
+}
+
+describe("ClaudeEngine", () => {
+  let engine: ClaudeEngine;
+
+  beforeEach(() => {
+    engine = new ClaudeEngine();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── 1. Identity ─────────────────────────────────────────────────────────────
+
+  describe("identity", () => {
+    it("has name 'claude'", () => {
+      expect(engine.name).toBe("claude");
+    });
+
+    it("implements InterruptibleEngine interface", () => {
+      expect(typeof engine.kill).toBe("function");
+      expect(typeof engine.isAlive).toBe("function");
+      expect(typeof engine.killAll).toBe("function");
+      expect(typeof engine.run).toBe("function");
+    });
+  });
+
+  // ── 2. Lifecycle (kill / isAlive / killAll) without spawn ────────────────────
+
+  describe("lifecycle with no running processes", () => {
+    it("isAlive returns false for unknown session", () => {
+      expect(engine.isAlive("nonexistent")).toBe(false);
+    });
+
+    it("kill does not throw for unknown session", () => {
+      expect(() => engine.kill("nonexistent")).not.toThrow();
+    });
+
+    it("killAll does not throw when no processes", () => {
+      expect(() => engine.killAll()).not.toThrow();
+    });
+  });
+
+  // ── 3. run() — successful non-streaming ─────────────────────────────────────
+
+  describe("run() — non-streaming success", () => {
+    it("resolves with result from JSON output", async () => {
+      const output = JSON.stringify({
+        type: "result",
+        result: "The answer is 42.",
+        session_id: "cl-sess-1",
+        total_cost_usd: 0.005,
+        duration_ms: 1200,
+        num_turns: 2,
+      });
+      const result = await runWithOutput(engine, { prompt: "question", cwd: "/tmp" }, [output]);
+      expect(result.result).toBe("The answer is 42.");
+      expect(result.sessionId).toBe("cl-sess-1");
+      expect(result.cost).toBe(0.005);
+      expect(result.durationMs).toBe(1200);
+      expect(result.numTurns).toBe(2);
+      expect(result.error).toBeUndefined();
+    });
+
+    it("resolves with result from Array JSON output", async () => {
+      const output = JSON.stringify([
+        { type: "assistant", message: { content: [{ type: "text", text: "thinking..." }] } },
+        {
+          type: "result",
+          result: "Array answer",
+          session_id: "cl-arr-1",
+          is_error: false,
+        },
+      ]);
+      const result = await runWithOutput(engine, { prompt: "q", cwd: "/tmp" }, [output]);
+      expect(result.result).toBe("Array answer");
+      expect(result.sessionId).toBe("cl-arr-1");
+    });
+
+    it("extracts assistant text from array when result is empty", async () => {
+      const output = JSON.stringify([
+        {
+          type: "assistant",
+          content: [{ type: "text", text: "fallback text" }],
+        },
+        { type: "result", result: "", session_id: "cl-empty" },
+      ]);
+      const result = await runWithOutput(engine, { prompt: "q", cwd: "/tmp" }, [output]);
+      expect(result.result).toBe("fallback text");
+    });
+
+    it("extracts text from role:assistant message format", async () => {
+      const output = JSON.stringify([
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "role-based fallback" }],
+        },
+        { type: "result", result: "", session_id: "cl-role" },
+      ]);
+      const result = await runWithOutput(engine, { prompt: "q", cwd: "/tmp" }, [output]);
+      expect(result.result).toBe("role-based fallback");
+    });
+
+    it("handles is_error=true in result event", async () => {
+      const output = JSON.stringify({
+        type: "result",
+        result: "Something went wrong",
+        session_id: "cl-err",
+        is_error: true,
+      });
+      const result = await runWithOutput(engine, { prompt: "q", cwd: "/tmp" }, [output]);
+      expect(result.error).toBeDefined();
+      expect(result.result).toBe("");
+    });
+
+    it("returns error when JSON parse fails", async () => {
+      const result = await runWithOutput(engine, { prompt: "q", cwd: "/tmp" }, ["not valid json!!!!"]);
+      expect(result.error).toContain("Failed to parse Claude output");
+    });
+
+    it("uses custom bin from opts", async () => {
+      const output = JSON.stringify({ type: "result", result: "ok", session_id: "cl-bin" });
+      await runWithOutput(engine, { prompt: "q", cwd: "/tmp", bin: "/usr/local/bin/claude" }, [output]);
+      expect(mockSpawn).toHaveBeenCalledWith("/usr/local/bin/claude", expect.any(Array), expect.any(Object));
+    });
+
+    it("defaults bin to 'claude'", async () => {
+      const output = JSON.stringify({ type: "result", result: "ok", session_id: "cl-def" });
+      await runWithOutput(engine, { prompt: "q", cwd: "/tmp" }, [output]);
+      expect(mockSpawn).toHaveBeenCalledWith("claude", expect.any(Array), expect.any(Object));
+    });
+  });
+
+  // ── 4. run() — args building ─────────────────────────────────────────────────
+
+  describe("run() — args building", () => {
+    async function captureArgs(opts: EngineRunOpts): Promise<string[]> {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+      const p = engine.run(opts);
+      proc.stdout.emit("data", Buffer.from(JSON.stringify({ type: "result", result: "ok", session_id: "" })));
+      proc.exitCode = 0;
+      proc.emit("close", 0);
+      await p;
+      return (mockSpawn.mock.lastCall?.[1] as string[]) ?? [];
+    }
+
+    it("includes --model when specified", async () => {
+      const args = await captureArgs({ prompt: "q", cwd: "/tmp", model: "claude-opus-4-5" });
+      expect(args).toContain("--model");
+      expect(args).toContain("claude-opus-4-5");
+    });
+
+    it("includes --resume when resumeSessionId is set", async () => {
+      const args = await captureArgs({ prompt: "q", cwd: "/tmp", resumeSessionId: "resume-abc" });
+      expect(args).toContain("--resume");
+      expect(args).toContain("resume-abc");
+    });
+
+    it("includes --effort when effortLevel is not default", async () => {
+      const args = await captureArgs({ prompt: "q", cwd: "/tmp", effortLevel: "high" });
+      expect(args).toContain("--effort");
+      expect(args).toContain("high");
+    });
+
+    it("does NOT include --effort when effortLevel is 'default'", async () => {
+      const args = await captureArgs({ prompt: "q", cwd: "/tmp", effortLevel: "default" });
+      expect(args).not.toContain("--effort");
+    });
+
+    it("includes --append-system-prompt when systemPrompt is set", async () => {
+      const args = await captureArgs({ prompt: "q", cwd: "/tmp", systemPrompt: "You are helpful." });
+      expect(args).toContain("--append-system-prompt");
+      expect(args).toContain("You are helpful.");
+    });
+
+    it("appends attachment list to prompt", async () => {
+      const args = await captureArgs({
+        prompt: "review this",
+        cwd: "/tmp",
+        attachments: ["/a/b.ts", "/c/d.ts"],
+      });
+      const promptArg = args.find((a) => a.includes("Attached files:"));
+      expect(promptArg).toContain("- /a/b.ts");
+      expect(promptArg).toContain("- /c/d.ts");
+    });
+
+    it("prompt comes before --mcp-config", async () => {
+      const args = await captureArgs({
+        prompt: "the-prompt",
+        cwd: "/tmp",
+        mcpConfigPath: "/etc/mcp.json",
+      });
+      const promptIdx = args.indexOf("the-prompt");
+      const mcpIdx = args.indexOf("--mcp-config");
+      expect(promptIdx).toBeGreaterThan(-1);
+      expect(mcpIdx).toBeGreaterThan(promptIdx);
+    });
+
+    it("appends cliFlags", async () => {
+      const args = await captureArgs({ prompt: "q", cwd: "/tmp", cliFlags: ["--debug", "--trace"] });
+      expect(args).toContain("--debug");
+      expect(args).toContain("--trace");
+    });
+
+    it("includes --include-partial-messages in streaming mode", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+      const p = engine.run({ prompt: "q", cwd: "/tmp", onStream: vi.fn(), sessionId: "stream-args" });
+      proc.emit("error", new Error("spawn error"));
+      try {
+        await p;
+      } catch {
+        /* expected */
+      }
+      const args = (mockSpawn.mock.lastCall?.[1] as string[]) ?? [];
+      expect(args).toContain("--include-partial-messages");
+    });
+  });
+
+  // ── 5. run() — error scenarios ───────────────────────────────────────────────
+
+  describe("run() — error scenarios", () => {
+    it("rejects on spawn error", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+      const p = engine.run({ prompt: "q", cwd: "/tmp" });
+      proc.emit("error", new Error("ENOENT: claude not found"));
+      await expect(p).rejects.toThrow("Failed to spawn Claude CLI");
+    });
+
+    it("resolves with error message on non-zero exit", async () => {
+      const result = await runWithOutput(
+        engine,
+        { prompt: "q", cwd: "/tmp" },
+        [],
+        127,
+      );
+      expect(result.error).toContain("127");
+    });
+
+    it("returns terminationReason when session is killed", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const p = engine.run({ prompt: "long task", cwd: "/tmp", sessionId: "kill-sess" });
+      engine.kill("kill-sess", "User cancelled");
+
+      proc.exitCode = null;
+      proc.emit("close", null);
+
+      const result = await p;
+      expect(result.error).toBe("User cancelled");
+    });
+
+    it("resolves with non-zero exit + stdout JSON (array with result)", async () => {
+      const output = JSON.stringify([
+        { type: "result", result: "partial", session_id: "cl-nz", is_error: false },
+      ]);
+      const result = await runWithOutput(engine, { prompt: "q", cwd: "/tmp" }, [output], 1);
+      expect(result.result).toBe("partial");
+    });
+
+    it("resolves with non-zero exit + stdout JSON (object result)", async () => {
+      const output = JSON.stringify({
+        type: "result",
+        result: "obj partial",
+        session_id: "cl-obj",
+        is_error: false,
+      });
+      const result = await runWithOutput(engine, { prompt: "q", cwd: "/tmp" }, [output], 1);
+      expect(result.result).toBe("obj partial");
+    });
+  });
+
+  // ── 6. run() — streaming ────────────────────────────────────────────────────
+
+  describe("run() — streaming", () => {
+    it("streams text deltas from stream_event content_block_delta", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const deltas: StreamDelta[] = [];
+      const p = engine.run({
+        prompt: "q",
+        cwd: "/tmp",
+        sessionId: "stream-1",
+        onStream: (d) => deltas.push(d),
+      });
+
+      const events = [
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_delta", delta: { type: "text_delta", text: "Hello " } },
+        }),
+        "\n",
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_delta", delta: { type: "text_delta", text: "world!" } },
+        }),
+        "\n",
+        JSON.stringify({ type: "result", result: "Hello world!", session_id: "s1" }),
+        "\n",
+      ].join("");
+
+      proc.stdout.emit("data", Buffer.from(events));
+      proc.exitCode = 0;
+      proc.emit("close", 0);
+
+      const result = await p;
+      expect(result.result).toBe("Hello world!");
+      expect(deltas.some((d) => d.type === "text" && d.content === "Hello ")).toBe(true);
+      expect(deltas.some((d) => d.type === "text" && d.content === "world!")).toBe(true);
+    });
+
+    it("streams tool_use and tool_result events", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const deltas: StreamDelta[] = [];
+      const p = engine.run({
+        prompt: "q",
+        cwd: "/tmp",
+        sessionId: "stream-tool",
+        onStream: (d) => deltas.push(d),
+      });
+
+      const events = [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            content_block: { type: "tool_use", name: "read_file", id: "tool-1" },
+          },
+        }),
+        "\n",
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop" },
+        }),
+        "\n",
+        JSON.stringify({ type: "result", result: "done", session_id: "s2" }),
+        "\n",
+      ].join("");
+
+      proc.stdout.emit("data", Buffer.from(events));
+      proc.exitCode = 0;
+      proc.emit("close", 0);
+
+      await p;
+      expect(deltas.some((d) => d.type === "tool_use" && d.toolName === "read_file")).toBe(true);
+      expect(deltas.some((d) => d.type === "tool_result")).toBe(true);
+    });
+
+    it("streams text_snapshot from assistant message", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const deltas: StreamDelta[] = [];
+      const p = engine.run({
+        prompt: "q",
+        cwd: "/tmp",
+        sessionId: "stream-snap",
+        onStream: (d) => deltas.push(d),
+      });
+
+      const events = [
+        JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "snapshot text" }] },
+        }),
+        "\n",
+        JSON.stringify({ type: "result", result: "snapshot text", session_id: "s3" }),
+        "\n",
+      ].join("");
+
+      proc.stdout.emit("data", Buffer.from(events));
+      proc.exitCode = 0;
+      proc.emit("close", 0);
+
+      await p;
+      expect(deltas.some((d) => d.type === "text_snapshot" && d.content === "snapshot text")).toBe(true);
+    });
+
+    it("emits status delta on retry when transient error occurs with prior work", async () => {
+      // Retry is triggered when: isTransientError=true AND isDeadSessionError=false
+      // isDeadSessionError=false requires numTurns>0 (work was done before the error).
+      // Achieve this with streaming + a result event (num_turns:1) on non-zero exit.
+      const proc1 = createMockProcess();
+      const proc2 = createMockProcess();
+
+      mockSpawn.mockImplementation(() => {
+        if (mockSpawn.mock.calls.length === 1) return proc1 as unknown as ChildProcess;
+        setTimeout(() => {
+          proc2.stdout.emit(
+            "data",
+            Buffer.from(
+              JSON.stringify({ type: "result", result: "ok", session_id: "s4", num_turns: 1 }) + "\n",
+            ),
+          );
+          proc2.exitCode = 0;
+          proc2.emit("close", 0);
+        }, 10);
+        return proc2 as unknown as ChildProcess;
+      });
+
+      const deltas: StreamDelta[] = [];
+      const p = engine.run({
+        prompt: "q",
+        cwd: "/tmp",
+        sessionId: "retry-stream",
+        onStream: (d) => deltas.push(d),
+      });
+
+      // First attempt: result event with is_error:true, socket hang up message, num_turns:1
+      // → numTurns=1 → isDeadSessionError=false
+      // → error contains "socket hang up" → isTransientError=true → retry fires
+      proc1.stdout.emit(
+        "data",
+        Buffer.from(
+          JSON.stringify({
+            type: "result",
+            result: "socket hang up during request",
+            session_id: "s-pre",
+            is_error: true,
+            num_turns: 1,
+          }) + "\n",
+        ),
+      );
+      proc1.exitCode = 1;
+      proc1.emit("close", 1);
+
+      await p;
+      expect(deltas.some((d) => d.type === "status" && String(d.content).includes("Retrying"))).toBe(true);
+    }, 10000);
+
+    it("resolves successfully with streaming run including rate_limit_event", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const p = engine.run({
+        prompt: "q",
+        cwd: "/tmp",
+        sessionId: "stream-rl",
+        onStream: vi.fn(),
+      });
+
+      // rate_limit_event alone (no result event) — falls back to non-streaming parse path
+      // Just verify the run completes without hanging
+      const rateLimitLine = JSON.stringify({
+        type: "rate_limit_event",
+        rate_limit_info: { status: "ok", resetsAt: 9999999, rateLimitType: "daily" },
+      });
+      proc.stdout.emit("data", Buffer.from(`${rateLimitLine}\n`));
+      proc.exitCode = 0;
+      proc.emit("close", 0);
+
+      // Should resolve (not hang)
+      const result = await p;
+      expect(result).toBeDefined();
+    });
+
+    it("resolves with error when result is_error=true (direct buildEngineResultFromResultEvent)", () => {
+      // Test the rate-limit-rejected path directly to avoid retry-loop timeout
+      // biome-ignore lint/suspicious/noExplicitAny: intentional private method access for testing
+      const build = (engine as any).buildEngineResultFromResultEvent.bind(engine);
+      const rateLimit = { status: "rejected", rateLimitType: "daily" };
+      const result = build(
+        { type: "result", result: "Usage limit hit", session_id: "s-rl2", is_error: true },
+        "Usage limit hit",
+        undefined,
+        rateLimit,
+      );
+      expect(result.error).toContain("usage limit reached");
+      expect(result.rateLimit?.status).toBe("rejected");
+    });
+  });
+
+  // ── 7. run() — isAlive tracking ─────────────────────────────────────────────
+
+  describe("run() — isAlive tracking", () => {
+    it("reports alive while running, false after close", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const p = engine.run({ prompt: "q", cwd: "/tmp", sessionId: "alive-cl" });
+
+      expect(engine.isAlive("alive-cl")).toBe(true);
+
+      proc.stdout.emit("data", Buffer.from(JSON.stringify({ type: "result", result: "ok", session_id: "alive-cl" })));
+      proc.exitCode = 0;
+      proc.emit("close", 0);
+
+      await p;
+      expect(engine.isAlive("alive-cl")).toBe(false);
+    });
+
+    it("killAll kills all running sessions", async () => {
+      const proc1 = createMockProcess();
+      const proc2 = createMockProcess();
+      mockSpawn
+        .mockReturnValueOnce(proc1 as unknown as ChildProcess)
+        .mockReturnValueOnce(proc2 as unknown as ChildProcess);
+
+      const p1 = engine.run({ prompt: "q1", cwd: "/tmp", sessionId: "all-1" });
+      const p2 = engine.run({ prompt: "q2", cwd: "/tmp", sessionId: "all-2" });
+
+      expect(engine.isAlive("all-1")).toBe(true);
+      expect(engine.isAlive("all-2")).toBe(true);
+
+      engine.killAll();
+
+      proc1.exitCode = null;
+      proc1.emit("close", null);
+      proc2.exitCode = null;
+      proc2.emit("close", null);
+
+      await Promise.all([p1, p2]);
+    });
+  });
+
+  // ── 8. Retry logic ───────────────────────────────────────────────────────────
+
+  describe("retry logic", () => {
+    it("does not retry on non-transient error", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const p = engine.run({ prompt: "q", cwd: "/tmp" });
+      proc.stderr.emit("data", Buffer.from("Permanent error: bad request"));
+      proc.exitCode = 2;
+      proc.emit("close", 2);
+
+      await p;
+      expect(mockSpawn).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not retry dead session errors", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const p = engine.run({ prompt: "q", cwd: "/tmp", resumeSessionId: "dead-sess" });
+      // Simulate dead session output
+      proc.stdout.emit(
+        "data",
+        Buffer.from(
+          JSON.stringify({
+            type: "result",
+            result: "Session has expired",
+            session_id: "",
+            is_error: true,
+          }),
+        ),
+      );
+      proc.exitCode = 0;
+      proc.emit("close", 0);
+
+      await p;
+      // Dead session should not retry (only 1 spawn call)
+      expect(mockSpawn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── 9. buildCleanEnv ────────────────────────────────────────────────────────
+
+  describe("buildCleanEnv", () => {
+    it("strips CLAUDECODE env var", async () => {
+      const origVar = process.env.CLAUDECODE;
+      process.env.CLAUDECODE = "should-be-stripped";
+
+      try {
+        const proc = createMockProcess();
+        mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+        const p = engine.run({ prompt: "q", cwd: "/tmp" });
+        proc.stdout.emit("data", Buffer.from(JSON.stringify({ type: "result", result: "ok", session_id: "" })));
+        proc.exitCode = 0;
+        proc.emit("close", 0);
+        await p;
+
+        const env = mockSpawn.mock.lastCall?.[2]?.env as Record<string, string>;
+        expect(env.CLAUDECODE).toBeUndefined();
+      } finally {
+        if (origVar !== undefined) process.env.CLAUDECODE = origVar;
+        else delete process.env.CLAUDECODE;
+      }
+    });
+
+    it("strips CLAUDE_CODE_* env vars", async () => {
+      const origVar = process.env.CLAUDE_CODE_SECRET;
+      process.env.CLAUDE_CODE_SECRET = "secret-value";
+
+      try {
+        const proc = createMockProcess();
+        mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+        const p = engine.run({ prompt: "q", cwd: "/tmp" });
+        proc.stdout.emit("data", Buffer.from(JSON.stringify({ type: "result", result: "ok", session_id: "" })));
+        proc.exitCode = 0;
+        proc.emit("close", 0);
+        await p;
+
+        const env = mockSpawn.mock.lastCall?.[2]?.env as Record<string, string>;
+        expect(env.CLAUDE_CODE_SECRET).toBeUndefined();
+      } finally {
+        if (origVar !== undefined) process.env.CLAUDE_CODE_SECRET = origVar;
+        else delete process.env.CLAUDE_CODE_SECRET;
+      }
+    });
+
+    it("preserves ANTHROPIC_API_KEY", async () => {
+      const origKey = process.env.ANTHROPIC_API_KEY;
+      process.env.ANTHROPIC_API_KEY = "test-key-123";
+
+      try {
+        const proc = createMockProcess();
+        mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+        const p = engine.run({ prompt: "q", cwd: "/tmp" });
+        proc.stdout.emit("data", Buffer.from(JSON.stringify({ type: "result", result: "ok", session_id: "" })));
+        proc.exitCode = 0;
+        proc.emit("close", 0);
+        await p;
+
+        const env = mockSpawn.mock.lastCall?.[2]?.env as Record<string, string>;
+        expect(env.ANTHROPIC_API_KEY).toBe("test-key-123");
+      } finally {
+        if (origKey !== undefined) process.env.ANTHROPIC_API_KEY = origKey;
+        else delete process.env.ANTHROPIC_API_KEY;
+      }
+    });
+  });
+
+  // ── 10. processStreamLine (via any cast) ─────────────────────────────────────
+
+  describe("processStreamLine (internal)", () => {
+    // Access private method for direct unit testing
+    // biome-ignore lint/suspicious/noExplicitAny: intentional private method access for testing
+    const psl = (line: string, count = 0, inTool = false) => (engine as any).processStreamLine(line, count, inTool);
+
+    it("returns null for empty line", () => {
+      expect(psl("")).toBeNull();
+      expect(psl("   ")).toBeNull();
+    });
+
+    it("returns null for unparseable JSON", () => {
+      expect(psl("not json at all")).toBeNull();
+    });
+
+    it("returns __result for type='result'", () => {
+      const line = JSON.stringify({ type: "result", result: "answer", session_id: "s1" });
+      const r = psl(line);
+      expect(r?.type).toBe("__result");
+      expect(r?.msg.result).toBe("answer");
+    });
+
+    it("returns __rate_limit for type='rate_limit_event'", () => {
+      const line = JSON.stringify({
+        type: "rate_limit_event",
+        rate_limit_info: { status: "ok", resetsAt: 9999 },
+      });
+      const r = psl(line);
+      expect(r?.type).toBe("__rate_limit");
+      expect(r?.info.status).toBe("ok");
+    });
+
+    it("returns null for rate_limit_event with no valid info", () => {
+      const line = JSON.stringify({ type: "rate_limit_event", rate_limit_info: null });
+      expect(psl(line)).toBeNull();
+    });
+
+    it("returns text_snapshot delta for assistant message with text", () => {
+      const line = JSON.stringify({
+        type: "assistant",
+        message: { content: [{ type: "text", text: "snapshot" }] },
+      });
+      const r = psl(line);
+      expect(r?.type).toBe("delta");
+      expect(r?.delta.type).toBe("text_snapshot");
+      expect(r?.delta.content).toBe("snapshot");
+    });
+
+    it("returns null for assistant message without text content", () => {
+      const line = JSON.stringify({
+        type: "assistant",
+        message: { content: [{ type: "image" }] },
+      });
+      expect(psl(line)).toBeNull();
+    });
+
+    it("returns null for assistant message without message field", () => {
+      const line = JSON.stringify({ type: "assistant" });
+      expect(psl(line)).toBeNull();
+    });
+
+    it("returns __tool_start for content_block_start tool_use", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: { type: "content_block_start", content_block: { type: "tool_use", name: "bash", id: "t1" } },
+      });
+      const r = psl(line);
+      expect(r?.type).toBe("__tool_start");
+      expect(r?.delta.toolName).toBe("bash");
+    });
+
+    it("returns delta text for content_block_delta text_delta when NOT inTool", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: { type: "content_block_delta", delta: { type: "text_delta", text: "hello" } },
+      });
+      const r = psl(line, 0, false);
+      expect(r?.type).toBe("delta");
+      expect(r?.delta.type).toBe("text");
+      expect(r?.delta.content).toBe("hello");
+    });
+
+    it("returns null for content_block_delta text_delta when inTool=true", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: { type: "content_block_delta", delta: { type: "text_delta", text: "hello" } },
+      });
+      expect(psl(line, 0, true)).toBeNull();
+    });
+
+    it("returns null for empty text in content_block_delta", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: { type: "content_block_delta", delta: { type: "text_delta", text: "" } },
+      });
+      expect(psl(line)).toBeNull();
+    });
+
+    it("returns __tool_end for content_block_stop when inTool=true", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: { type: "content_block_stop" },
+      });
+      const r = psl(line, 0, true);
+      expect(r?.type).toBe("__tool_end");
+      expect(r?.delta.type).toBe("tool_result");
+    });
+
+    it("returns null for stream_event without event field", () => {
+      const line = JSON.stringify({ type: "stream_event" });
+      expect(psl(line)).toBeNull();
+    });
+
+    it("returns null for stream_event with unknown event type", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: { type: "some_future_event" },
+      });
+      expect(psl(line)).toBeNull();
+    });
+
+    it("returns null for content_block_start non-tool_use", () => {
+      const line = JSON.stringify({
+        type: "stream_event",
+        event: { type: "content_block_start", content_block: { type: "text" } },
+      });
+      expect(psl(line)).toBeNull();
+    });
+
+    it("returns null for unrecognized top-level type", () => {
+      const line = JSON.stringify({ type: "future_type", data: "x" });
+      expect(psl(line)).toBeNull();
+    });
+
+    it("logs first 5 lines at debug level (no throw)", () => {
+      // Just ensure no throw for early lines
+      for (let i = 0; i <= 5; i++) {
+        expect(() => psl(JSON.stringify({ type: "result", result: "ok" }), i)).not.toThrow();
+      }
+    });
+  });
+
+  // ── 11. parseRateLimitInfo edge cases (via any cast) ─────────────────────────
+
+  describe("parseRateLimitInfo (internal)", () => {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional private method access for testing
+    const pri = (v: unknown) => (engine as any).parseRateLimitInfo(v);
+
+    it("returns undefined for null", () => {
+      expect(pri(null)).toBeUndefined();
+    });
+
+    it("returns undefined for non-object", () => {
+      expect(pri("string")).toBeUndefined();
+    });
+
+    it("returns undefined for empty object (no recognized fields)", () => {
+      expect(pri({})).toBeUndefined();
+    });
+
+    it("parses resetsAt as numeric string", () => {
+      const result = pri({ resetsAt: "1234567890" });
+      expect(result?.resetsAt).toBe(1234567890);
+    });
+
+    it("parses all known fields", () => {
+      const result = pri({
+        status: "ok",
+        resetsAt: 9999,
+        rateLimitType: "daily",
+        overageStatus: "active",
+        overageDisabledReason: "none",
+        isUsingOverage: true,
+      });
+      expect(result?.status).toBe("ok");
+      expect(result?.rateLimitType).toBe("daily");
+      expect(result?.isUsingOverage).toBe(true);
+    });
+  });
+});

--- a/packages/jimmy/src/engines/__tests__/codex.test.ts
+++ b/packages/jimmy/src/engines/__tests__/codex.test.ts
@@ -1,0 +1,783 @@
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EngineRunOpts, StreamDelta } from "../../shared/types.js";
+import { CodexEngine } from "../codex.js";
+
+// Mock child_process.spawn
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+import { spawn } from "node:child_process";
+
+const mockSpawn = vi.mocked(spawn);
+
+interface MockProcess {
+  emit: EventEmitter["emit"];
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  stdin: { end: ReturnType<typeof vi.fn> };
+  pid: number;
+  exitCode: number | null;
+  killed: boolean;
+  kill: ReturnType<typeof vi.fn>;
+}
+
+function createMockProcess(): MockProcess {
+  const emitter = new EventEmitter();
+  const proc: MockProcess = Object.assign(emitter, {
+    stdout: new EventEmitter(),
+    stderr: new EventEmitter(),
+    stdin: { end: vi.fn() },
+    pid: 22222,
+    exitCode: null as number | null,
+    killed: false,
+    kill: vi.fn(() => {
+      proc.killed = true;
+      return true;
+    }),
+  });
+  return proc;
+}
+
+describe("CodexEngine", () => {
+  let engine: CodexEngine;
+
+  beforeEach(() => {
+    engine = new CodexEngine();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── 1. Identity ─────────────────────────────────────────────────────────────
+
+  describe("identity", () => {
+    it("has name 'codex'", () => {
+      expect(engine.name).toBe("codex");
+    });
+
+    it("implements InterruptibleEngine interface", () => {
+      expect(typeof engine.kill).toBe("function");
+      expect(typeof engine.isAlive).toBe("function");
+      expect(typeof engine.killAll).toBe("function");
+      expect(typeof engine.run).toBe("function");
+    });
+  });
+
+  // ── 2. Lifecycle (kill / isAlive / killAll) without spawn ────────────────────
+
+  describe("lifecycle with no running processes", () => {
+    it("isAlive returns false for unknown session", () => {
+      expect(engine.isAlive("nonexistent")).toBe(false);
+    });
+
+    it("kill does not throw for unknown session", () => {
+      expect(() => engine.kill("nonexistent")).not.toThrow();
+    });
+
+    it("killAll does not throw when no processes", () => {
+      expect(() => engine.killAll()).not.toThrow();
+    });
+  });
+
+  // ── 3. buildFreshArgs (via any cast) ─────────────────────────────────────────
+
+  describe("buildFreshArgs (internal)", () => {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional private method access for testing
+    const bfa = (opts: EngineRunOpts, prompt: string) => (engine as any).buildFreshArgs(opts, prompt);
+
+    it("starts with 'exec'", () => {
+      const args = bfa({ prompt: "q", cwd: "/tmp" }, "q");
+      expect(args[0]).toBe("exec");
+    });
+
+    it("includes --model when specified", () => {
+      const args = bfa({ prompt: "q", cwd: "/tmp", model: "o4-mini" }, "q");
+      expect(args).toContain("--model");
+      expect(args).toContain("o4-mini");
+    });
+
+    it("includes effort config when effortLevel is not default", () => {
+      const args = bfa({ prompt: "q", cwd: "/tmp", effortLevel: "high" }, "q");
+      expect(args).toContain("-c");
+      expect(args.some((a: string) => a.includes("high"))).toBe(true);
+    });
+
+    it("does NOT include effort config when effortLevel is 'default'", () => {
+      const args = bfa({ prompt: "q", cwd: "/tmp", effortLevel: "default" }, "q");
+      expect(args).not.toContain("-c");
+    });
+
+    it("includes --json and --color never", () => {
+      const args = bfa({ prompt: "q", cwd: "/tmp" }, "q");
+      expect(args).toContain("--json");
+      expect(args).toContain("never");
+    });
+
+    it("includes -C with cwd", () => {
+      const args = bfa({ prompt: "q", cwd: "/my/dir" }, "q");
+      expect(args).toContain("-C");
+      expect(args).toContain("/my/dir");
+    });
+
+    it("appends cliFlags", () => {
+      const args = bfa({ prompt: "q", cwd: "/tmp", cliFlags: ["--flag1"] }, "q");
+      expect(args).toContain("--flag1");
+    });
+
+    it("puts prompt as last argument", () => {
+      const args = bfa({ prompt: "q", cwd: "/tmp" }, "my-prompt");
+      expect(args[args.length - 1]).toBe("my-prompt");
+    });
+  });
+
+  // ── 4. buildResumeArgs (via any cast) ────────────────────────────────────────
+
+  describe("buildResumeArgs (internal)", () => {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional private method access for testing
+    const bra = (opts: EngineRunOpts, prompt: string) => (engine as any).buildResumeArgs(opts, prompt);
+
+    it("starts with 'exec resume'", () => {
+      const args = bra({ prompt: "q", cwd: "/tmp", resumeSessionId: "tid-abc" }, "q");
+      expect(args[0]).toBe("exec");
+      expect(args[1]).toBe("resume");
+    });
+
+    it("includes resumeSessionId before prompt", () => {
+      const args = bra({ prompt: "q", cwd: "/tmp", resumeSessionId: "tid-xyz" }, "my-prompt");
+      const tidIdx = args.indexOf("tid-xyz");
+      const promptIdx = args.indexOf("my-prompt");
+      expect(tidIdx).toBeGreaterThan(-1);
+      expect(promptIdx).toBeGreaterThan(tidIdx);
+    });
+
+    it("throws when resumeSessionId is not provided", () => {
+      expect(() => bra({ prompt: "q", cwd: "/tmp" }, "q")).toThrow("resumeSessionId is required");
+    });
+
+    it("includes --model when specified", () => {
+      const args = bra({ prompt: "q", cwd: "/tmp", resumeSessionId: "t1", model: "o4" }, "q");
+      expect(args).toContain("--model");
+      expect(args).toContain("o4");
+    });
+  });
+
+  // ── 5. processJsonlLine (via any cast) ───────────────────────────────────────
+
+  describe("processJsonlLine (internal)", () => {
+    // biome-ignore lint/suspicious/noExplicitAny: intentional private method access for testing
+    const pjl = (line: string) => (engine as any).processJsonlLine(line);
+
+    it("returns null for empty line", () => {
+      expect(pjl("")).toBeNull();
+      expect(pjl("   ")).toBeNull();
+    });
+
+    it("returns null for unparseable JSON", () => {
+      expect(pjl("not json")).toBeNull();
+    });
+
+    it("parses thread.started → thread_id", () => {
+      const line = JSON.stringify({ type: "thread.started", thread_id: "th-abc" });
+      const r = pjl(line);
+      expect(r?.type).toBe("thread_id");
+      expect(r?.threadId).toBe("th-abc");
+    });
+
+    it("parses item.started command_execution → tool_start", () => {
+      const line = JSON.stringify({
+        type: "item.started",
+        item: { type: "command_execution", command: "ls -la", id: "cmd-1" },
+      });
+      const r = pjl(line);
+      expect(r?.type).toBe("tool_start");
+      expect(r?.delta.toolName).toBe("command_execution");
+      expect(r?.delta.content).toContain("ls -la");
+    });
+
+    it("parses item.started file_edit → tool_start", () => {
+      const line = JSON.stringify({
+        type: "item.started",
+        item: { type: "file_edit", file_path: "/src/foo.ts", id: "fe-1" },
+      });
+      const r = pjl(line);
+      expect(r?.type).toBe("tool_start");
+      expect(r?.delta.toolName).toBe("file_edit");
+      expect(r?.delta.content).toContain("foo.ts");
+    });
+
+    it("parses item.started file_read → tool_start", () => {
+      const line = JSON.stringify({
+        type: "item.started",
+        item: { type: "file_read", filename: "bar.ts", id: "fr-1" },
+      });
+      const r = pjl(line);
+      expect(r?.type).toBe("tool_start");
+      expect(r?.delta.toolName).toBe("file_read");
+    });
+
+    it("returns null for item.started with unknown item type", () => {
+      const line = JSON.stringify({
+        type: "item.started",
+        item: { type: "unknown_item" },
+      });
+      expect(pjl(line)).toBeNull();
+    });
+
+    it("returns null for item.started without item field", () => {
+      const line = JSON.stringify({ type: "item.started" });
+      expect(pjl(line)).toBeNull();
+    });
+
+    it("parses item.completed agent_message → text", () => {
+      const line = JSON.stringify({
+        type: "item.completed",
+        item: { type: "agent_message", text: "Hello from codex!" },
+      });
+      const r = pjl(line);
+      expect(r?.type).toBe("text");
+      expect(r?.delta.content).toBe("Hello from codex!");
+    });
+
+    it("returns null for agent_message with empty text", () => {
+      const line = JSON.stringify({
+        type: "item.completed",
+        item: { type: "agent_message", text: "" },
+      });
+      expect(pjl(line)).toBeNull();
+    });
+
+    it("parses item.completed command_execution → tool_end", () => {
+      const line = JSON.stringify({
+        type: "item.completed",
+        item: {
+          type: "command_execution",
+          command: "echo hi",
+          aggregated_output: "hi",
+          exit_code: 0,
+        },
+      });
+      const r = pjl(line);
+      expect(r?.type).toBe("tool_end");
+      expect(r?.delta.type).toBe("tool_result");
+      expect(r?.delta.content).toContain("hi");
+    });
+
+    it("parses item.completed command_execution with no output", () => {
+      const line = JSON.stringify({
+        type: "item.completed",
+        item: { type: "command_execution", command: "exit", aggregated_output: "", exit_code: 0 },
+      });
+      const r = pjl(line);
+      expect(r?.type).toBe("tool_end");
+      expect(r?.delta.content).toContain("exit (exit 0)");
+    });
+
+    it("parses item.completed file_edit → tool_end", () => {
+      const line = JSON.stringify({
+        type: "item.completed",
+        item: { type: "file_edit", file_path: "/src/a.ts" },
+      });
+      const r = pjl(line);
+      expect(r?.type).toBe("tool_end");
+      expect(r?.delta.content).toContain("a.ts");
+    });
+
+    it("parses item.completed file_read → tool_end", () => {
+      const line = JSON.stringify({
+        type: "item.completed",
+        item: { type: "file_read", file_path: "/src/b.ts" },
+      });
+      const r = pjl(line);
+      expect(r?.type).toBe("tool_end");
+      expect(r?.delta.content).toContain("b.ts");
+    });
+
+    it("parses item.completed error → error", () => {
+      const line = JSON.stringify({
+        type: "item.completed",
+        item: { type: "error", message: "Something failed" },
+      });
+      const r = pjl(line);
+      expect(r?.type).toBe("error");
+      expect(r?.message).toBe("Something failed");
+    });
+
+    it("suppresses Under-development features warning", () => {
+      const line = JSON.stringify({
+        type: "item.completed",
+        item: { type: "error", message: "Under-development features not available" },
+      });
+      expect(pjl(line)).toBeNull();
+    });
+
+    it("suppresses Model metadata warning", () => {
+      const line = JSON.stringify({
+        type: "item.completed",
+        item: { type: "error", message: "Model metadata fetch failed" },
+      });
+      expect(pjl(line)).toBeNull();
+    });
+
+    it("returns null for item.completed with unknown item type", () => {
+      const line = JSON.stringify({
+        type: "item.completed",
+        item: { type: "unknown_item" },
+      });
+      expect(pjl(line)).toBeNull();
+    });
+
+    it("returns null for item.completed without item", () => {
+      const line = JSON.stringify({ type: "item.completed" });
+      expect(pjl(line)).toBeNull();
+    });
+
+    it("parses turn.completed → usage", () => {
+      const line = JSON.stringify({ type: "turn.completed" });
+      const r = pjl(line);
+      expect(r?.type).toBe("usage");
+    });
+
+    it("parses turn.failed → turn_failed", () => {
+      const line = JSON.stringify({
+        type: "turn.failed",
+        error: { message: "Turn failed due to X" },
+      });
+      const r = pjl(line);
+      expect(r?.type).toBe("turn_failed");
+      expect(r?.message).toBe("Turn failed due to X");
+    });
+
+    it("parses error → error", () => {
+      const line = JSON.stringify({ type: "error", message: "Top-level error" });
+      const r = pjl(line);
+      expect(r?.type).toBe("error");
+      expect(r?.message).toBe("Top-level error");
+    });
+
+    it("returns null for unrecognized event type", () => {
+      const line = JSON.stringify({ type: "future_event", data: "x" });
+      expect(pjl(line)).toBeNull();
+    });
+  });
+
+  // ── 6. run() — successful run ────────────────────────────────────────────────
+
+  describe("run() — success", () => {
+    it("resolves with result text and thread_id", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const p = engine.run({ prompt: "hello", cwd: "/tmp", sessionId: "cx-1" });
+
+      const events = [
+        JSON.stringify({ type: "thread.started", thread_id: "th-cx-1" }),
+        "\n",
+        JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "Hello from Codex!" } }),
+        "\n",
+        JSON.stringify({ type: "turn.completed" }),
+        "\n",
+      ].join("");
+
+      proc.stdout.emit("data", Buffer.from(events));
+      proc.exitCode = 0;
+      proc.emit("close", 0);
+
+      const result = await p;
+      expect(result.sessionId).toBe("th-cx-1");
+      expect(result.result).toBe("Hello from Codex!");
+      expect(result.numTurns).toBe(1);
+      expect(result.error).toBeUndefined();
+    });
+
+    it("uses resumeSessionId for resume args", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const p = engine.run({
+        prompt: "continue",
+        cwd: "/tmp",
+        resumeSessionId: "th-resume-1",
+        sessionId: "cx-resume",
+      });
+
+      proc.stdout.emit(
+        "data",
+        Buffer.from(
+          JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "Resumed!" } }) + "\n",
+        ),
+      );
+      proc.exitCode = 0;
+      proc.emit("close", 0);
+
+      const result = await p;
+      expect(result.result).toBe("Resumed!");
+      const args = mockSpawn.mock.lastCall?.[1] as string[];
+      expect(args).toContain("resume");
+      expect(args).toContain("th-resume-1");
+    });
+
+    it("prepends systemPrompt to prompt", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const p = engine.run({
+        prompt: "user task",
+        cwd: "/tmp",
+        systemPrompt: "Be precise.",
+        sessionId: "cx-sys",
+      });
+
+      proc.stdout.emit(
+        "data",
+        Buffer.from(
+          JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "done" } }) + "\n",
+        ),
+      );
+      proc.exitCode = 0;
+      proc.emit("close", 0);
+
+      await p;
+      const args = mockSpawn.mock.lastCall?.[1] as string[];
+      const promptArg = args[args.length - 1];
+      expect(promptArg).toContain("Be precise.");
+      expect(promptArg).toContain("user task");
+    });
+
+    it("appends attachments to prompt", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const p = engine.run({
+        prompt: "review",
+        cwd: "/tmp",
+        attachments: ["/a/b.ts"],
+        sessionId: "cx-att",
+      });
+
+      proc.stdout.emit(
+        "data",
+        Buffer.from(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "ok" } }) + "\n"),
+      );
+      proc.exitCode = 0;
+      proc.emit("close", 0);
+
+      await p;
+      const args = mockSpawn.mock.lastCall?.[1] as string[];
+      const promptArg = args[args.length - 1];
+      expect(promptArg).toContain("/a/b.ts");
+    });
+
+    it("defaults bin to 'codex'", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const p = engine.run({ prompt: "q", cwd: "/tmp", sessionId: "cx-bin" });
+      proc.stdout.emit(
+        "data",
+        Buffer.from(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "ok" } }) + "\n"),
+      );
+      proc.exitCode = 0;
+      proc.emit("close", 0);
+
+      await p;
+      expect(mockSpawn).toHaveBeenCalledWith("codex", expect.any(Array), expect.any(Object));
+    });
+
+    it("uses custom bin when specified", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const p = engine.run({ prompt: "q", cwd: "/tmp", bin: "/custom/codex", sessionId: "cx-cbin" });
+      proc.stdout.emit(
+        "data",
+        Buffer.from(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "ok" } }) + "\n"),
+      );
+      proc.exitCode = 0;
+      proc.emit("close", 0);
+
+      await p;
+      expect(mockSpawn).toHaveBeenCalledWith("/custom/codex", expect.any(Array), expect.any(Object));
+    });
+  });
+
+  // ── 7. run() — streaming ────────────────────────────────────────────────────
+
+  describe("run() — streaming", () => {
+    it("streams tool_start, tool_end and text deltas", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const deltas: StreamDelta[] = [];
+      const p = engine.run({
+        prompt: "do work",
+        cwd: "/tmp",
+        sessionId: "cx-stream",
+        onStream: (d) => deltas.push(d),
+      });
+
+      const events = [
+        JSON.stringify({ type: "thread.started", thread_id: "th-s1" }),
+        "\n",
+        JSON.stringify({
+          type: "item.started",
+          item: { type: "command_execution", command: "ls", id: "cmd-s1" },
+        }),
+        "\n",
+        JSON.stringify({
+          type: "item.completed",
+          item: { type: "command_execution", command: "ls", aggregated_output: "file.ts", exit_code: 0 },
+        }),
+        "\n",
+        JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "Done." } }),
+        "\n",
+      ].join("");
+
+      proc.stdout.emit("data", Buffer.from(events));
+      proc.exitCode = 0;
+      proc.emit("close", 0);
+
+      const result = await p;
+      expect(result.result).toBe("Done.");
+      expect(deltas.some((d) => d.type === "tool_use" && d.toolName === "command_execution")).toBe(true);
+      expect(deltas.some((d) => d.type === "tool_result")).toBe(true);
+      expect(deltas.some((d) => d.type === "text" && d.content === "Done.")).toBe(true);
+    });
+
+    it("streams error event", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const deltas: StreamDelta[] = [];
+      const p = engine.run({
+        prompt: "q",
+        cwd: "/tmp",
+        sessionId: "cx-err-stream",
+        onStream: (d) => deltas.push(d),
+      });
+
+      proc.stdout.emit(
+        "data",
+        Buffer.from(JSON.stringify({ type: "error", message: "API error occurred" }) + "\n"),
+      );
+      proc.exitCode = 1;
+      proc.emit("close", 1);
+
+      const result = await p;
+      expect(result.error).toBeDefined();
+      expect(deltas.some((d) => d.type === "error")).toBe(true);
+    });
+
+    it("streams turn_failed event", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const deltas: StreamDelta[] = [];
+      const p = engine.run({
+        prompt: "q",
+        cwd: "/tmp",
+        sessionId: "cx-tf-stream",
+        onStream: (d) => deltas.push(d),
+      });
+
+      proc.stdout.emit(
+        "data",
+        Buffer.from(
+          JSON.stringify({ type: "turn.failed", error: { message: "Turn failed hard" } }) + "\n",
+        ),
+      );
+      proc.exitCode = 1;
+      proc.emit("close", 1);
+
+      await p;
+      expect(deltas.some((d) => d.type === "error" && String(d.content).includes("Turn failed hard"))).toBe(true);
+    });
+  });
+
+  // ── 8. run() — error scenarios ───────────────────────────────────────────────
+
+  describe("run() — error scenarios", () => {
+    it("rejects on spawn error", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const p = engine.run({ prompt: "q", cwd: "/tmp", sessionId: "cx-spawn-err" });
+      proc.emit("error", new Error("ENOENT: codex not found"));
+
+      await expect(p).rejects.toThrow("Failed to spawn Codex CLI");
+    });
+
+    it("resolves with error on non-zero exit with no thread", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const p = engine.run({ prompt: "q", cwd: "/tmp", sessionId: "cx-nz" });
+      proc.stderr.emit("data", Buffer.from("codex: error occurred"));
+      proc.exitCode = 1;
+      proc.emit("close", 1);
+
+      const result = await p;
+      expect(result.error).toContain("1");
+    });
+
+    it("resolves with result when non-zero exit but thread_id acquired", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const p = engine.run({ prompt: "q", cwd: "/tmp", sessionId: "cx-partial" });
+
+      const events = [
+        JSON.stringify({ type: "thread.started", thread_id: "th-partial" }),
+        "\n",
+        JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "partial answer" } }),
+        "\n",
+      ].join("");
+
+      proc.stdout.emit("data", Buffer.from(events));
+      proc.exitCode = 1;
+      proc.emit("close", 1);
+
+      const result = await p;
+      expect(result.sessionId).toBe("th-partial");
+      expect(result.result).toBe("partial answer");
+    });
+
+    it("resolves with terminationReason when killed", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const p = engine.run({ prompt: "long task", cwd: "/tmp", sessionId: "cx-kill" });
+      engine.kill("cx-kill", "User cancelled");
+
+      proc.exitCode = null;
+      proc.emit("close", null);
+
+      const result = await p;
+      expect(result.error).toBe("User cancelled");
+    });
+
+    it("processes remaining lineBuf on close", async () => {
+      const proc = createMockProcess();
+      mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+
+      const p = engine.run({ prompt: "q", cwd: "/tmp", sessionId: "cx-buf" });
+
+      // Send data without trailing newline — will be in lineBuf at close
+      proc.stdout.emit(
+        "data",
+        Buffer.from(JSON.stringify({ type: "thread.started", thread_id: "th-buf" })),
+      );
+      proc.exitCode = 0;
+      proc.emit("close", 0);
+
+      const result = await p;
+      expect(result.sessionId).toBe("th-buf");
+    });
+  });
+
+  // ── 9. run() — isAlive tracking ─────────────────────────────────────────────
+
+  describe("run() — isAlive tracking", () => {
+    it("killAll kills all running sessions", async () => {
+      const proc1 = createMockProcess();
+      const proc2 = createMockProcess();
+      mockSpawn
+        .mockReturnValueOnce(proc1 as unknown as ChildProcess)
+        .mockReturnValueOnce(proc2 as unknown as ChildProcess);
+
+      const p1 = engine.run({ prompt: "q1", cwd: "/tmp", sessionId: "cx-all-1" });
+      const p2 = engine.run({ prompt: "q2", cwd: "/tmp", sessionId: "cx-all-2" });
+
+      engine.killAll();
+
+      proc1.exitCode = null;
+      proc1.emit("close", null);
+      proc2.exitCode = null;
+      proc2.emit("close", null);
+
+      const [r1, r2] = await Promise.all([p1, p2]);
+      expect(r1.error).toContain("gateway shutting down");
+      expect(r2.error).toContain("gateway shutting down");
+    });
+  });
+
+  // ── 10. buildCleanEnv ───────────────────────────────────────────────────────
+
+  describe("buildCleanEnv", () => {
+    it("strips CLAUDE_CODE_* vars", async () => {
+      const origVar = process.env.CLAUDE_CODE_FOO;
+      process.env.CLAUDE_CODE_FOO = "stripped";
+
+      try {
+        const proc = createMockProcess();
+        mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+        const p = engine.run({ prompt: "q", cwd: "/tmp", sessionId: "cx-env1" });
+        proc.stdout.emit(
+          "data",
+          Buffer.from(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "ok" } }) + "\n"),
+        );
+        proc.exitCode = 0;
+        proc.emit("close", 0);
+        await p;
+
+        const env = mockSpawn.mock.lastCall?.[2]?.env as Record<string, string>;
+        expect(env.CLAUDE_CODE_FOO).toBeUndefined();
+      } finally {
+        if (origVar !== undefined) process.env.CLAUDE_CODE_FOO = origVar;
+        else delete process.env.CLAUDE_CODE_FOO;
+      }
+    });
+
+    it("strips CODEX vars", async () => {
+      const origVar = process.env.CODEX;
+      process.env.CODEX = "stripped";
+
+      try {
+        const proc = createMockProcess();
+        mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+        const p = engine.run({ prompt: "q", cwd: "/tmp", sessionId: "cx-env2" });
+        proc.stdout.emit(
+          "data",
+          Buffer.from(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "ok" } }) + "\n"),
+        );
+        proc.exitCode = 0;
+        proc.emit("close", 0);
+        await p;
+
+        const env = mockSpawn.mock.lastCall?.[2]?.env as Record<string, string>;
+        expect(env.CODEX).toBeUndefined();
+      } finally {
+        if (origVar !== undefined) process.env.CODEX = origVar;
+        else delete process.env.CODEX;
+      }
+    });
+
+    it("strips CODEX_* vars", async () => {
+      const origVar = process.env.CODEX_API_KEY;
+      process.env.CODEX_API_KEY = "secret";
+
+      try {
+        const proc = createMockProcess();
+        mockSpawn.mockReturnValue(proc as unknown as ChildProcess);
+        const p = engine.run({ prompt: "q", cwd: "/tmp", sessionId: "cx-env3" });
+        proc.stdout.emit(
+          "data",
+          Buffer.from(JSON.stringify({ type: "item.completed", item: { type: "agent_message", text: "ok" } }) + "\n"),
+        );
+        proc.exitCode = 0;
+        proc.emit("close", 0);
+        await p;
+
+        const env = mockSpawn.mock.lastCall?.[2]?.env as Record<string, string>;
+        expect(env.CODEX_API_KEY).toBeUndefined();
+      } finally {
+        if (origVar !== undefined) process.env.CODEX_API_KEY = origVar;
+        else delete process.env.CODEX_API_KEY;
+      }
+    });
+  });
+});


### PR DESCRIPTION
## 概要

🚧 作業中（Epic 仕様書承認済み、Task 実装済み）

- Epic 仕様書: `docs/requirements/ES-007-engine-mocks.md`
- Phase: Phase 2（PD-002: コードベース構造改善）
- 対応 Epic: E7（テスト拡充 — engines サブグループ）

`engines/claude.ts`・`engines/codex.ts` に `vi.mock("node:child_process")` パターンでテストを追加し、branch カバレッジを 0% → 70%+ に引き上げる。

## 変更内容

| ファイル | 内容 |
|---------|------|
| `docs/requirements/ES-007-engine-mocks.md` | Epic 仕様書（新規作成） |
| `docs/research/complexity-and-di-analysis.md` | Phase 2 複雑度・DI 分析レポート |
| `packages/jimmy/src/engines/__tests__/claude.test.ts` | ClaudeEngine テスト（875行・63テスト） |
| `packages/jimmy/src/engines/__tests__/codex.test.ts` | CodexEngine テスト（783行・58テスト） |

## 関連 Issue

Closes #74

## テスト結果

- `pnpm test`: 645 passed（34 test files）
- `pnpm build`: PASS