### PR TITLE
refactor(ES-012): Composition Root — gateway/container.ts にファクトリ抽出

### DIFF
--- a/docs/requirements/ES-012-composition-root.md
+++ b/docs/requirements/ES-012-composition-root.md
@@ -1,0 +1,32 @@
+<!-- 配置先: docs/requirements/ES-012-composition-root.md -->
+# ES-012: E2 — Composition Root
+
+| 項目 | 内容 |
+|------|------|
+| ステータス | 承認済み |
+| 日付 | 2026-04-25 |
+| 対応 Issue | #86 |
+| 対応ストーリー | S2 |
+| Phase 定義書 | docs/requirements/PD-002-code-restructuring.md |
+
+## 概要
+
+`gateway/server.ts` の `startGateway()` 内でインラインに生成していたエンジン依存・コネクター名を `gateway/container.ts` のファクトリ関数として分離し、Composition Root パターンを確立する。
+
+## 解消方針
+
+| 関数 | 責務 |
+|------|------|
+| `buildEngines(config)` | Claude / Codex / Gemini エンジンを生成して `Map<string, Engine>` で返す |
+| `buildConnectorNames(config)` | 設定から有効なコネクター名リストを生成して返す |
+
+`startGateway` はファクトリを呼び出して組み立てる thin orchestrator になる。
+
+## Acceptance Criteria
+
+| # | AC | 検証方法 |
+|---|-----|---------|
+| AC-1 | `gateway/container.ts` が新規作成され `buildEngines` / `buildConnectorNames` が export されている | ファイル存在・grep 確認 |
+| AC-2 | `gateway/server.ts` の `startGateway` がエンジン生成を `buildEngines` に委譲している | grep 確認 |
+| AC-3 | cleanup 処理が `engines.values()` をイテレートして `killAll` を呼ぶ汎用実装になっている | コード確認 |
+| AC-4 | `pnpm build && pnpm test` が全 PASS | コマンド出力確認 |

--- a/packages/jimmy/src/gateway/__tests__/container.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/container.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { buildConnectorNames, buildEngines } from "../container.js";
+import type { JinnConfig } from "../../shared/types.js";
+
+function makeConfig(connectors: JinnConfig["connectors"] = {}): JinnConfig {
+  return {
+    gateway: { port: 7777, host: "0.0.0.0" },
+    engines: { default: "claude", claude: { bin: "claude", model: "sonnet" }, codex: { bin: "codex", model: "" } },
+    connectors,
+    logging: { file: false, stdout: false, level: "info" },
+  } as unknown as JinnConfig;
+}
+
+describe("buildEngines", () => {
+  it("claude / codex / gemini の 3 エンジンを返す", () => {
+    const engines = buildEngines();
+    expect(engines.size).toBe(3);
+    expect(engines.has("claude")).toBe(true);
+    expect(engines.has("codex")).toBe(true);
+    expect(engines.has("gemini")).toBe(true);
+  });
+
+  it("各エンジンが run メソッドを持つ", () => {
+    const engines = buildEngines();
+    for (const engine of engines.values()) {
+      expect(typeof engine.run).toBe("function");
+    }
+  });
+});
+
+describe("buildConnectorNames", () => {
+  it("コネクター設定がない場合は空配列を返す", () => {
+    expect(buildConnectorNames(makeConfig())).toEqual([]);
+  });
+
+  it("slack の appToken と botToken が揃っている場合に slack を含む", () => {
+    const config = makeConfig({ slack: { appToken: "xapp-1", botToken: "xoxb-1" } } as JinnConfig["connectors"]);
+    expect(buildConnectorNames(config)).toContain("slack");
+  });
+
+  it("slack の片方だけの場合は slack を含まない", () => {
+    const config = makeConfig({ slack: { appToken: "xapp-1" } } as JinnConfig["connectors"]);
+    expect(buildConnectorNames(config)).not.toContain("slack");
+  });
+
+  it("discord の botToken がある場合に discord を含む", () => {
+    const config = makeConfig({ discord: { botToken: "tok" } } as JinnConfig["connectors"]);
+    expect(buildConnectorNames(config)).toContain("discord");
+  });
+
+  it("discord の proxyVia がある場合に discord を含む", () => {
+    const config = makeConfig({ discord: { proxyVia: "http://proxy" } } as JinnConfig["connectors"]);
+    expect(buildConnectorNames(config)).toContain("discord");
+  });
+
+  it("telegram の botToken がある場合に telegram を含む", () => {
+    const config = makeConfig({ telegram: { botToken: "tel-tok" } } as JinnConfig["connectors"]);
+    expect(buildConnectorNames(config)).toContain("telegram");
+  });
+
+  it("whatsapp 設定がある場合に whatsapp を含む", () => {
+    const config = makeConfig({ whatsapp: {} } as JinnConfig["connectors"]);
+    expect(buildConnectorNames(config)).toContain("whatsapp");
+  });
+
+  it("複数コネクターが有効な場合に全て含む", () => {
+    const config = makeConfig({
+      slack: { appToken: "xapp-1", botToken: "xoxb-1" },
+      telegram: { botToken: "tel-tok" },
+    } as JinnConfig["connectors"]);
+    const names = buildConnectorNames(config);
+    expect(names).toContain("slack");
+    expect(names).toContain("telegram");
+    expect(names).not.toContain("discord");
+    expect(names).not.toContain("whatsapp");
+  });
+});

--- a/packages/jimmy/src/gateway/container.ts
+++ b/packages/jimmy/src/gateway/container.ts
@@ -3,8 +3,8 @@ import { CodexEngine } from "../engines/codex.js";
 import { GeminiEngine } from "../engines/gemini.js";
 import type { Engine, JinnConfig } from "../shared/types.js";
 
-/** Build the engine map from config. Each engine key matches JinnConfig.engines keys. */
-export function buildEngines(_config: JinnConfig): Map<string, Engine> {
+/** Build the engine map. Each key matches JinnConfig.engines keys. */
+export function buildEngines(): Map<string, Engine> {
   const engines = new Map<string, Engine>();
   engines.set("claude", new ClaudeEngine());
   engines.set("codex", new CodexEngine());

--- a/packages/jimmy/src/gateway/container.ts
+++ b/packages/jimmy/src/gateway/container.ts
@@ -1,0 +1,31 @@
+import { ClaudeEngine } from "../engines/claude.js";
+import { CodexEngine } from "../engines/codex.js";
+import { GeminiEngine } from "../engines/gemini.js";
+import type { Engine, JinnConfig } from "../shared/types.js";
+
+/** Build the engine map from config. Each engine key matches JinnConfig.engines keys. */
+export function buildEngines(_config: JinnConfig): Map<string, Engine> {
+  const engines = new Map<string, Engine>();
+  engines.set("claude", new ClaudeEngine());
+  engines.set("codex", new CodexEngine());
+  engines.set("gemini", new GeminiEngine());
+  return engines;
+}
+
+/** Derive the list of active connector names from config. */
+export function buildConnectorNames(config: JinnConfig): string[] {
+  const names: string[] = [];
+  if (config.connectors?.slack?.appToken && config.connectors?.slack?.botToken) {
+    names.push("slack");
+  }
+  if (config.connectors?.discord?.botToken || config.connectors?.discord?.proxyVia) {
+    names.push("discord");
+  }
+  if (config.connectors?.telegram?.botToken) {
+    names.push("telegram");
+  }
+  if (config.connectors?.whatsapp) {
+    names.push("whatsapp");
+  }
+  return names;
+}

--- a/packages/jimmy/src/gateway/server.ts
+++ b/packages/jimmy/src/gateway/server.ts
@@ -24,12 +24,13 @@ import {
 } from "../sessions/registry.js";
 import { loadConfig } from "../shared/config.js";
 import { configureLogger, logger } from "../shared/logger.js";
-import type {
-  Connector,
-  JinnConfig,
-  SlackConnectorConfig,
-  TelegramConnectorConfig,
-  WhatsAppConnectorConfig,
+import {
+  isInterruptibleEngine,
+  type Connector,
+  type JinnConfig,
+  type SlackConnectorConfig,
+  type TelegramConnectorConfig,
+  type WhatsAppConnectorConfig,
 } from "../shared/types.js";
 import { initStt } from "../stt/stt.js";
 import { type ApiContext, handleApiRequest, resumePendingWebQueueItems } from "./api.js";
@@ -716,7 +717,7 @@ export async function startGateway(config: JinnConfig): Promise<GatewayCleanup> 
 
     // Terminate live engine subprocesses after marking sessions.
     for (const engine of engines.values()) {
-      if ("killAll" in engine && typeof engine.killAll === "function") engine.killAll();
+      if (isInterruptibleEngine(engine)) engine.killAll();
     }
 
     // Stop cron scheduler

--- a/packages/jimmy/src/gateway/server.ts
+++ b/packages/jimmy/src/gateway/server.ts
@@ -12,10 +12,8 @@ import { TelegramConnector } from "../connectors/telegram/index.js";
 import { WhatsAppConnector } from "../connectors/whatsapp/index.js";
 import { loadJobs } from "../cron/jobs.js";
 import { reloadScheduler, startScheduler, stopScheduler } from "../cron/scheduler.js";
-import { ClaudeEngine } from "../engines/claude.js";
-import { CodexEngine } from "../engines/codex.js";
-import { GeminiEngine } from "../engines/gemini.js";
 import { type RouteOptions, SessionManager } from "../sessions/manager.js";
+import { buildConnectorNames, buildEngines } from "./container.js";
 import {
   getInterruptedSessions,
   initDb,
@@ -135,34 +133,9 @@ export async function startGateway(config: JinnConfig): Promise<GatewayCleanup> 
     logger.info(`Recovered ${recoveredQueue} in-flight queue item(s) from previous run — reset to pending`);
   }
 
-  // Set up engines
-  const claudeEngine = new ClaudeEngine();
-  const codexEngine = new CodexEngine();
-  const geminiEngine = new GeminiEngine();
-  const engines = new Map<
-    string,
-    InstanceType<typeof ClaudeEngine> | InstanceType<typeof CodexEngine> | InstanceType<typeof GeminiEngine>
-  >();
-  engines.set("claude", claudeEngine);
-  engines.set("codex", codexEngine);
-  engines.set("gemini", geminiEngine);
-
-  // Derive connector names from config
-  const connectorNames: string[] = [];
-  if (config.connectors?.slack?.appToken && config.connectors?.slack?.botToken) {
-    connectorNames.push("slack");
-  }
-  if (config.connectors?.discord?.botToken || config.connectors?.discord?.proxyVia) {
-    connectorNames.push("discord");
-  }
-  if (config.connectors?.telegram?.botToken) {
-    connectorNames.push("telegram");
-  }
-  if (config.connectors?.whatsapp) {
-    connectorNames.push("whatsapp");
-  }
-
-  // Session manager
+  // Assemble dependencies via Composition Root factories
+  const engines = buildEngines(config);
+  const connectorNames = buildConnectorNames(config);
   const sessionManager = new SessionManager(config, engines, connectorNames);
 
   // Build employee registry
@@ -742,8 +715,9 @@ export async function startGateway(config: JinnConfig): Promise<GatewayCleanup> 
     }
 
     // Terminate live engine subprocesses after marking sessions.
-    claudeEngine.killAll();
-    codexEngine.killAll();
+    for (const engine of engines.values()) {
+      if ("killAll" in engine && typeof engine.killAll === "function") engine.killAll();
+    }
 
     // Stop cron scheduler
     stopScheduler();

--- a/packages/jimmy/src/gateway/server.ts
+++ b/packages/jimmy/src/gateway/server.ts
@@ -134,7 +134,7 @@ export async function startGateway(config: JinnConfig): Promise<GatewayCleanup> 
   }
 
   // Assemble dependencies via Composition Root factories
-  const engines = buildEngines(config);
+  const engines = buildEngines();
   const connectorNames = buildConnectorNames(config);
   const sessionManager = new SessionManager(config, engines, connectorNames);
 


### PR DESCRIPTION
## 概要

Phase 2 E2: `startGateway()` の依存生成をファクトリ関数に分離し Composition Root パターンを確立。

## 変更内容

| ファイル | 変更 |
|---------|------|
| `gateway/container.ts` | 新規作成 — `buildEngines()` / `buildConnectorNames()` を定義 |
| `gateway/server.ts` | エンジン生成・コネクター名生成をファクトリに委譲、`killAll()` を汎用化 |
| `docs/requirements/ES-012-composition-root.md` | Epic 仕様書 |

## 検証結果

- `pnpm typecheck`: ✅ エラーなし
- `pnpm test`: ✅ 645 tests PASS

Closes #86