### PR TITLE
feat: ES-024 コネクター共通リトライ・バックオフユーティリティ

### DIFF
--- a/docs/requirements/ES-024-connector-retry-backoff.md
+++ b/docs/requirements/ES-024-connector-retry-backoff.md
@@ -1,0 +1,44 @@
+# ES-024: コネクター共通基底 — リトライ・バックオフユーティリティ統一
+
+| 項目 | 内容 |
+|------|------|
+| Epic ID | ES-024 |
+| Phase | Phase 2: コードベース構造改善 |
+| Story | S19: コネクターのエラーリトライ・バックオフ処理を共通基底に統一 |
+| Issue | #148 |
+| Priority | Medium |
+| Complexity | S |
+
+## 概要
+
+WhatsApp コネクターのインライン指数バックオフ計算を `packages/jimmy/src/shared/retry.ts` に共通ユーティリティとして抽出する。
+各コネクターが独自にリトライロジックを実装せずに済む基盤を整備し、動作を予測可能にする。
+
+## ストーリー
+
+**S19**: As a **開発者**, I want to コネクターのエラーリトライ・バックオフ処理を共通基底に統一したい, so that 各コネクターが独自にリトライを実装する必要がなくなり、動作が予測可能になる.
+
+## 受け入れ条件
+
+### AC-E024-01: `shared/retry.ts` の `exponentialBackoffMs` が正しい遅延を返す
+
+- `exponentialBackoffMs(0, 5000, 60000)` → `5000`
+- `exponentialBackoffMs(1, 5000, 60000)` → `10000`
+- `exponentialBackoffMs(10, 5000, 60000)` → `60000`（maxMs でキャップ）
+
+### AC-E024-02: `shared/retry.ts` の `withRetry` が成功まで最大N回リトライする
+
+- 成功時は最初の試行で即座に結果を返す
+- 失敗時はリトライして最終的に成功した結果を返す
+- `maxAttempts` 回失敗した場合は最後のエラーをスローする
+- `onRetry` コールバックが正しい attempt 番号で呼ばれる
+
+### AC-E024-03: `whatsapp/index.ts` が `exponentialBackoffMs` を使うようリファクタリング済み
+
+- `scheduleReconnect()` のインライン計算 `Math.min(5000 * 2 ** this.reconnectAttempts, 60000)` が
+  `exponentialBackoffMs(this.reconnectAttempts, 5000, 60000)` に置き換えられている
+
+### AC-E024-04: `pnpm test` 全 PASS
+
+- `packages/jimmy` のすべてのテストが通過すること
+- 新規テストファイル `shared/__tests__/retry.test.ts` が追加されていること

--- a/packages/jimmy/src/connectors/whatsapp/index.ts
+++ b/packages/jimmy/src/connectors/whatsapp/index.ts
@@ -17,6 +17,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { logger } from "../../shared/logger.js";
 import { JINN_HOME } from "../../shared/paths.js";
+import { exponentialBackoffMs } from "../../shared/retry.js";
 import type { Connector, ConnectorCapabilities, ConnectorHealth, IncomingMessage, Target } from "../../shared/types.js";
 import { formatResponse } from "./format.js";
 
@@ -79,7 +80,7 @@ export class WhatsAppConnector implements Connector {
   private scheduleReconnect(): void {
     if (this.connectionStatus === "stopped") return;
     // Exponential backoff: 5s, 10s, 20s, 40s, 60s max
-    const delay = Math.min(5000 * 2 ** this.reconnectAttempts, 60000);
+    const delay = exponentialBackoffMs(this.reconnectAttempts, 5000, 60000);
     this.reconnectAttempts++;
     logger.info(`WhatsApp reconnecting in ${delay / 1000}s (attempt ${this.reconnectAttempts})`);
     this.reconnectTimer = setTimeout(() => this.connect(), delay);

--- a/packages/jimmy/src/shared/__tests__/retry.test.ts
+++ b/packages/jimmy/src/shared/__tests__/retry.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+import { exponentialBackoffMs, withRetry } from "../retry.js";
+
+describe("exponentialBackoffMs", () => {
+  it("attempt=0 returns baseMs", () => {
+    expect(exponentialBackoffMs(0, 5000, 60000)).toBe(5000);
+  });
+
+  it("attempt=1 returns baseMs * 2", () => {
+    expect(exponentialBackoffMs(1, 5000, 60000)).toBe(10000);
+  });
+
+  it("large attempt is capped at maxMs", () => {
+    expect(exponentialBackoffMs(10, 5000, 60000)).toBe(60000);
+  });
+
+  it("attempt=2 returns baseMs * 4", () => {
+    expect(exponentialBackoffMs(2, 5000, 60000)).toBe(20000);
+  });
+});
+
+describe("withRetry", () => {
+  it("returns result on first success without retry", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const result = await withRetry(fn, { maxAttempts: 3, baseMs: 0, maxMs: 0 });
+    expect(result).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries on failure and eventually succeeds", async () => {
+    const fn = vi.fn().mockRejectedValueOnce(new Error("fail")).mockResolvedValue("success");
+    const result = await withRetry(fn, { maxAttempts: 3, baseMs: 0, maxMs: 0 });
+    expect(result).toBe("success");
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after maxAttempts are exhausted", async () => {
+    const error = new Error("always fails");
+    const fn = vi.fn().mockRejectedValue(error);
+    await expect(withRetry(fn, { maxAttempts: 3, baseMs: 0, maxMs: 0 })).rejects.toThrow("always fails");
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it("calls onRetry with correct attempt number", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("e1"))
+      .mockRejectedValueOnce(new Error("e2"))
+      .mockResolvedValue("done");
+    const onRetry = vi.fn();
+    await withRetry(fn, { maxAttempts: 3, baseMs: 0, maxMs: 0, onRetry });
+    expect(onRetry).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenNthCalledWith(1, 0, expect.any(Error));
+    expect(onRetry).toHaveBeenNthCalledWith(2, 1, expect.any(Error));
+  });
+
+  it("does not call onRetry on the final failing attempt", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("fail"));
+    const onRetry = vi.fn();
+    await expect(withRetry(fn, { maxAttempts: 2, baseMs: 0, maxMs: 0, onRetry })).rejects.toThrow();
+    // called for attempt 0 (i=0 < maxAttempts-1=1), NOT for attempt 1 (i=1 is the last)
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/jimmy/src/shared/retry.ts
+++ b/packages/jimmy/src/shared/retry.ts
@@ -1,0 +1,30 @@
+/**
+ * Compute exponential backoff delay in milliseconds.
+ * delay = min(baseMs * 2^attempt, maxMs)
+ */
+export function exponentialBackoffMs(attempt: number, baseMs: number, maxMs: number): number {
+  return Math.min(baseMs * 2 ** attempt, maxMs);
+}
+
+/**
+ * Retry an async operation with exponential backoff.
+ * Returns the result on success, throws on final failure.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  opts: { maxAttempts: number; baseMs: number; maxMs: number; onRetry?: (attempt: number, err: unknown) => void },
+): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 0; i < opts.maxAttempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (i < opts.maxAttempts - 1) {
+        opts.onRetry?.(i, err);
+        await new Promise((r) => setTimeout(r, exponentialBackoffMs(i, opts.baseMs, opts.maxMs)));
+      }
+    }
+  }
+  throw lastErr;
+}


### PR DESCRIPTION
Epic: #148

## 概要

`shared/retry.ts` に `exponentialBackoffMs` と `withRetry` を新設。WhatsApp のインライン実装を共通ユーティリティに置き換え。

## 変更内容

| ファイル | 内容 |
|---------|------|
| `shared/retry.ts` | `exponentialBackoffMs` + `withRetry<T>` 新規実装 |
| `shared/__tests__/retry.test.ts` | 9テスト追加 |
| `connectors/whatsapp/index.ts` | インライン backoff → `exponentialBackoffMs` に置換 |
| `docs/requirements/ES-024-connector-retry-backoff.md` | Epic 仕様書 |

## 検証結果

- `pnpm test`: 962 PASS（+9件）
- biome: 警告ゼロ、typecheck: PASS

## 関連 Issue

Closes #148
Closes #149