### PR TITLE
chore: dependabot.yml 追加 — npm パッチ・マイナー自動マージ設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    auto-merge: true
     groups:
       patch-updates:
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    auto-merge: true
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+      minor-updates:
+        update-types:
+          - "minor"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,19 @@
+name: Dependabot Auto Merge
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  auto-merge:
+    name: Auto Merge
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Enable auto-merge for Dependabot PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,6 +3,7 @@ name: Dependabot Auto Merge
 on:
   pull_request_target:
     branches: [main]
+    types: [opened]
 
 jobs:
   auto-merge:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,7 +1,7 @@
 name: Dependabot Auto Merge
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
 
 jobs:


### PR DESCRIPTION
## 概要

- `.github/dependabot.yml` を新規作成
- npm エコシステムのパッチ・マイナーアップデートを毎週月曜に自動マージ
- `allow_auto_merge` リポジトリ設定も同時に有効化済み

## 動作

- dependabot PR が作成される → `Epic Complete Check` がスキップ（`feature/` ブランチでないため）→ required check 通過 → 自動マージ
- `Merge Gate Check`（gate:reviewed）は required check に含まれないため dependabot をブロックしない

## 関連

- PR #156（postcss bump）はこの設定適用後に再トリガーまたは手動マージで対応