### PR TITLE
docs: PD-003 テストカバレッジ 90% 達成 Phase定義書

### DIFF
--- a/docs/requirements/PD-002-code-restructuring.md
+++ b/docs/requirements/PD-002-code-restructuring.md
@@ -3,8 +3,9 @@
 
 | 項目 | 内容 |
 |------|------|
-| ステータス | 承認済み |
+| ステータス | 完了 |
 | 日付 | 2026-04-25 |
+| 完了日 | 2026-04-28 |
 | 例外承認 Issue | — |
 
 ## 1. ビジョンと背景
@@ -154,11 +155,11 @@ graph LR
 
 ## 9. 成功基準
 
-- [ ] `gateway/api.ts` が 500 行以下のファイルに分割されている（期限: Phase 2 完了時点）
-- [ ] `npx madge --circular src/` でゼロ循環依存を達成する（期限: Phase 2 完了時点）
-- [ ] `sessions/manager.ts` が 500 行以下になり、EngineRunner が独立モジュールとして存在する（期限: Phase 2 完了時点）
-- [ ] branch カバレッジが 40% 以上を達成する（期限: Phase 2 完了時点）
-- [ ] `pnpm build && pnpm test` が全て PASS する（既存動作を維持する）（期限: Phase 2 完了時点）
+- [x] `gateway/api.ts` が 500 行以下のファイルに分割されている（実績: 39行）
+- [x] `npx madge --circular src/` でゼロ循環依存を達成する（実績: ゼロ件）
+- [x] `sessions/manager.ts` が 500 行以下になり、EngineRunner が独立モジュールとして存在する（実績: 273行）
+- [x] branch カバレッジが 40% 以上を達成する（実績: 44.31%）
+- [x] `pnpm build && pnpm test` が全て PASS する（既存動作を維持する）
 
 ## 10. Impact Mapping
 

--- a/docs/requirements/PD-003-test-coverage-90.md
+++ b/docs/requirements/PD-003-test-coverage-90.md
@@ -1,0 +1,44 @@
+<!-- 配置先: docs/requirements/PD-003-test-coverage-90.md — 相対リンクはこの配置先を前提としている -->
+<!-- このフォーマットは Phase 12 以降の軽量版。ADR-013 参照 -->
+# PD-003: Phase 3 — テストカバレッジ 90% 達成
+
+| 項目 | 内容 |
+|------|------|
+| ステータス | 承認済み |
+| 日付 | 2026-04-28 |
+
+## 1. 実現したいこと（機能意図一覧）
+
+- branch カバレッジを現状 50% から 90% に向上させる
+- 対象モジュール優先順: `src/mcp`（0%）、`src/stt`（0%）、`src/cli`（3%）、`src/gateway/api`（31%）、`src/gateway`（33%）、`src/sessions`（66%）、`src/engines`（78%）
+- `src/shared`（87%）、`src/cron`（96%）は既に高いため対象外
+
+## 2. Epic マッピング
+
+| # | Epic 名 | 対応する機能意図 | 優先度 |
+|---|---------|---------------|--------|
+| E1 | src/mcp テストカバレッジ向上 Epic | ・`src/mcp`（0% → 90%以上）のテスト追加 | MUST |
+| E2 | src/stt テストカバレッジ向上 Epic | ・`src/stt`（0% → 90%以上）のテスト追加 | MUST |
+| E3 | src/cli テストカバレッジ向上 Epic | ・`src/cli`（3% → 90%以上）のテスト追加 | MUST |
+| E4 | src/gateway/api テストカバレッジ向上 Epic | ・`src/gateway/api`（31% → 90%以上）のテスト追加 | MUST |
+| E5 | src/gateway テストカバレッジ向上 Epic | ・`src/gateway`（33% → 90%以上）のテスト追加 | MUST |
+| E6 | src/sessions テストカバレッジ向上 Epic | ・`src/sessions`（66% → 90%以上）のテスト追加 | MUST |
+| E7 | src/engines テストカバレッジ向上 Epic | ・`src/engines`（78% → 90%以上）のテスト追加 | MUST |
+
+## 3. Won't Have（スコープ外）
+
+- `src/shared`（87%）のカバレッジ向上（理由: 既に基準値近くであり、追加コストに対する効果が低い）
+- `src/cron`（96%）のカバレッジ向上（理由: 既に基準値を大幅に超えている）
+- 機能拡張（Antigravity エンジン、クロスセッション記憶、多層スキル管理 等）（理由: Phase 4 以降で対応する）
+
+---
+
+### 成功基準
+
+- [ ] branch カバレッジが全体で 90% 以上に到達する
+- [ ] 優先対象モジュール（mcp / stt / cli / gateway/api / gateway / sessions / engines）がそれぞれ 90% 以上を達成する
+
+### 参照ドキュメント
+
+- Phase 定義書 Issue: https://github.com/spikestudio/unstopia-gateway/issues/174
+- Milestone: Phase 3: テストカバレッジ 90% 達成


### PR DESCRIPTION
## Summary

- PD-003 Phase 定義書（`docs/requirements/PD-003-test-coverage-90.md`）を作成
- テストカバレッジを現状 50% → 90% に向上させる Phase 3 の機能意図・Epic マッピング・Won't Have を定義
- 対象 7 モジュール（mcp/stt/cli/gateway/api/sessions/engines）を MUST Epic として割り付け

## Test plan

- [ ] Phase 定義書のフォーマットが軽量版テンプレート（3セクション構成）に準拠している
- [ ] Epic マッピングが「1 Epic = 1 機能」原則に従っている（7 Epic に分割済み）
- [ ] Won't Have にスコープ外の理由が明記されている
- [ ] Milestone `Phase 3: テストカバレッジ 90% 達成` が作成・紐付けされている

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)