### PR TITLE
ci: merge-guard に [WIP] タイトルチェックを追加

### DIFF
--- a/.github/workflows/merge-guard.yml
+++ b/.github/workflows/merge-guard.yml
@@ -74,6 +74,22 @@ jobs:
     permissions:
       pull-requests: read
     steps:
+      - name: Check WIP title
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TITLE=$(gh pr view ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --json title --jq '.title')
+
+          if echo "$TITLE" | grep -qi '\[WIP\]'; then
+            echo "::error::PR タイトルに [WIP] が含まれています: $TITLE"
+            echo "  /aidd-review epic を実行して [WIP] を除去してからマージしてください。"
+            exit 1
+          fi
+
+          echo "✅ PR タイトルに [WIP] はありません。"
+
       - name: Verify all gate labels
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- `[WIP]` タイトルのまま PR がマージされる事故の再発防止（Phase 3 retro #254）
- `check-gates` ジョブの先頭に PR タイトルチェックを追加

## Changes

- `.github/workflows/merge-guard.yml`: `[WIP]` タイトル検出で merge をブロック

## Test plan

- [x] `actionlint` pass
- [x] ワークフロー syntax 確認済み

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)