### PR TITLE
fix(test): biome フォーマット・lint エラー修正

### DIFF
--- a/packages/jimmy/src/gateway/__tests__/lifecycle.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/lifecycle.test.ts
@@ -359,19 +359,17 @@ describe("startForeground()", () => {
     (startGateway as ReturnType<typeof vi.fn>).mockResolvedValue(mockCleanup);
 
     let sigintHandler: (() => void) | undefined;
-    const onSpy = vi.spyOn(process, "on").mockImplementation(
-      (event: string | symbol, handler: (...args: unknown[]) => void) => {
+    const onSpy = vi
+      .spyOn(process, "on")
+      .mockImplementation((event: string | symbol, handler: (...args: unknown[]) => void) => {
         if (event === "SIGINT") sigintHandler = handler as () => void;
         return process;
-      },
-    );
+      });
     let exitCode: number | undefined;
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(
-      (code?: string | number | null) => {
-        exitCode = typeof code === "number" ? code : 0;
-        return undefined as never;
-      },
-    );
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null) => {
+      exitCode = typeof code === "number" ? code : 0;
+      return undefined as never;
+    });
 
     await startForeground({} as never);
 
@@ -402,19 +400,17 @@ describe("startForeground()", () => {
     (startGateway as ReturnType<typeof vi.fn>).mockResolvedValue(mockCleanup);
 
     let sigintHandler: (() => void) | undefined;
-    const onSpy = vi.spyOn(process, "on").mockImplementation(
-      (event: string | symbol, handler: (...args: unknown[]) => void) => {
+    const onSpy = vi
+      .spyOn(process, "on")
+      .mockImplementation((event: string | symbol, handler: (...args: unknown[]) => void) => {
         if (event === "SIGINT") sigintHandler = handler as () => void;
         return process;
-      },
-    );
+      });
     let exitCode: number | undefined;
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(
-      (code?: string | number | null) => {
-        exitCode = typeof code === "number" ? code : 0;
-        return undefined as never;
-      },
-    );
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((code?: string | number | null) => {
+      exitCode = typeof code === "number" ? code : 0;
+      return undefined as never;
+    });
 
     vi.useFakeTimers();
 

--- a/packages/jimmy/src/gateway/__tests__/org-update.test.ts
+++ b/packages/jimmy/src/gateway/__tests__/org-update.test.ts
@@ -146,7 +146,7 @@ rank: employee
 
   it("returns false when ORG_DIR does not exist (line 75 true branch)", () => {
     // Point tmpDir at a non-existent path so existsSync returns false
-    tmpDir = path.join(os.tmpdir(), "no-such-dir-" + Date.now());
+    tmpDir = path.join(os.tmpdir(), `no-such-dir-${Date.now()}`);
     const result = updateEmployeeYaml("anyone", { alwaysNotify: false });
     expect(result).toBe(false);
   });

--- a/packages/jimmy/src/gateway/api/__tests__/session-runner-override.test.ts
+++ b/packages/jimmy/src/gateway/api/__tests__/session-runner-override.test.ts
@@ -15,7 +15,11 @@ vi.mock("../../../shared/logger.js", () => ({
 vi.mock("../../org.js", () => ({ scanOrg: vi.fn().mockReturnValue({}), findEmployee: vi.fn() }));
 vi.mock("../../org-hierarchy.js", () => ({ resolveOrgHierarchy: vi.fn().mockReturnValue({}) }));
 vi.mock("../session-fallback.js", () => ({ defaultFallbackDeps: {}, switchToFallback: vi.fn() }));
-vi.mock("../session-rate-limit.js", () => ({ defaultRateLimitDeps: {}, handleRateLimit: vi.fn(), retryUntilDeadline: vi.fn() }));
+vi.mock("../session-rate-limit.js", () => ({
+  defaultRateLimitDeps: {},
+  handleRateLimit: vi.fn(),
+  retryUntilDeadline: vi.fn(),
+}));
 vi.mock("../../../sessions/context.js", () => ({ buildContext: vi.fn().mockReturnValue("sys") }));
 vi.mock("../../../shared/effort.js", () => ({ resolveEffort: vi.fn().mockReturnValue("medium") }));
 vi.mock("../../../shared/paths.js", () => ({ JINN_HOME: "/mock/jinn" }));
@@ -26,10 +30,17 @@ import { maybeRevertEngineOverride } from "../session-runner.js";
 
 const makeSession = (overrides: Partial<Session> = {}): Session =>
   ({
-    id: "s1", engine: "codex", engineSessionId: "codex-1", source: "web",
-    sourceRef: "web:1", connector: "web", status: "running",
-    createdAt: new Date().toISOString(), lastActivity: new Date().toISOString(),
-    transportMeta: null, ...overrides,
+    id: "s1",
+    engine: "codex",
+    engineSessionId: "codex-1",
+    source: "web",
+    sourceRef: "web:1",
+    connector: "web",
+    status: "running",
+    createdAt: new Date().toISOString(),
+    lastActivity: new Date().toISOString(),
+    transportMeta: null,
+    ...overrides,
   }) as Session;
 
 describe("maybeRevertEngineOverride", () => {
@@ -45,7 +56,9 @@ describe("maybeRevertEngineOverride", () => {
 
   it("should return session unchanged when originalEngine is not a string", () => {
     const s = makeSession({
-      transportMeta: { engineOverride: { originalEngine: 42, until: new Date(Date.now() - 1000).toISOString() } } as never,
+      transportMeta: {
+        engineOverride: { originalEngine: 42, until: new Date(Date.now() - 1000).toISOString() },
+      } as never,
     });
     expect(maybeRevertEngineOverride(s)).toBe(s);
   });

--- a/packages/jimmy/src/sessions/repositories/__tests__/SqliteSessionRepository.test.ts
+++ b/packages/jimmy/src/sessions/repositories/__tests__/SqliteSessionRepository.test.ts
@@ -171,4 +171,3 @@ describe("SqliteSessionRepository", () => {
     });
   });
 });
-


### PR DESCRIPTION
## Summary

CI で検出された biome エラーを修正。

## Changes

- `org-update.test.ts`: 文字列連結 → テンプレートリテラル (`useTemplate`)
- `lifecycle.test.ts`: biome フォーマット修正
- `SqliteSessionRepository.test.ts`: 末尾余分空行除去

## Test plan

- [x] `pnpm lint` pass
- [x] `pnpm typecheck` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)