### PR TITLE
chore: Docker セットアップ追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+**/node_modules
+**/dist
+**/.next
+**/out
+.git
+docker/data
+*.log
+.env
+.env.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,13 @@ COPY --from=builder /app/package.json ./
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
+# Run as non-root (Docker security best practice; claude requires non-root execution)
+RUN groupadd --gid 1001 jinn && useradd --uid 1001 --gid 1001 --create-home jinn
+RUN mkdir -p /data && chown jinn:jinn /data
+USER jinn
+
 ENV JINN_HOME=/data
+ENV HOME=/home/jinn
 ENV NODE_ENV=production
 
 VOLUME ["/data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# ── Stage 1: Build ───────────────────────────────────────────────────────────
+FROM node:22 AS builder
+WORKDIR /app
+
+RUN npm install -g pnpm@10.6.4
+
+COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./
+COPY packages/jimmy/package.json ./packages/jimmy/
+COPY packages/web/package.json ./packages/web/
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+RUN pnpm build
+
+# ── Stage 2: Runner ───────────────────────────────────────────────────────────
+FROM node:22-slim AS runner
+WORKDIR /app
+
+# Install claude CLI
+RUN npm install -g @anthropic-ai/claude-code
+
+# Copy build artifacts and dependencies
+COPY --from=builder /app/packages/jimmy/dist ./packages/jimmy/dist
+COPY --from=builder /app/packages/jimmy/template ./packages/jimmy/template
+COPY --from=builder /app/packages/jimmy/package.json ./packages/jimmy/
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/packages/jimmy/node_modules ./packages/jimmy/node_modules
+COPY --from=builder /app/package.json ./
+
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENV JINN_HOME=/data
+ENV NODE_ENV=production
+
+VOLUME ["/data"]
+EXPOSE 7777
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       # Persistent data (config, sessions, org, logs...)
       - ./docker/data:/data
       # Mount host claude credentials so auth is shared
-      - ~/.claude:/root/.claude:ro
+      - ~/.claude:/home/jinn/.claude:ro
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  jinn:
+    build: .
+    ports:
+      - "7777:7777"
+    volumes:
+      # Persistent data (config, sessions, org, logs...)
+      - ./docker/data:/data
+      # Mount host claude credentials so auth is shared
+      - ~/.claude:/root/.claude:ro
+    environment:
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+    restart: unless-stopped

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,0 +1,2 @@
+data/*
+!data/.gitkeep

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -e
+
+# First-run initialization: populate JINN_HOME with defaults
+if [ ! -f "$JINN_HOME/config.yaml" ]; then
+  echo "[jinn] First run — initializing $JINN_HOME"
+
+  mkdir -p \
+    "$JINN_HOME/sessions" \
+    "$JINN_HOME/org" \
+    "$JINN_HOME/logs" \
+    "$JINN_HOME/tmp" \
+    "$JINN_HOME/skills" \
+    "$JINN_HOME/docs" \
+    "$JINN_HOME/files" \
+    "$JINN_HOME/cron/runs" \
+    "$JINN_HOME/.claude/skills" \
+    "$JINN_HOME/.agents/skills"
+
+  cp /app/packages/jimmy/template/config.default.yaml "$JINN_HOME/config.yaml"
+  cp /app/packages/jimmy/template/CLAUDE.md "$JINN_HOME/CLAUDE.md" 2>/dev/null || true
+  cp /app/packages/jimmy/template/AGENTS.md "$JINN_HOME/AGENTS.md" 2>/dev/null || true
+
+  # Bind to all interfaces so the port is reachable from the host
+  sed -i 's/host: "127.0.0.1"/host: "0.0.0.0"/' "$JINN_HOME/config.yaml"
+
+  echo "[jinn] Done. Edit $JINN_HOME/config.yaml to customize."
+fi
+
+# Run pending migrations automatically
+node /app/packages/jimmy/dist/bin/jimmy.js migrate 2>/dev/null || true
+
+exec node /app/packages/jimmy/dist/bin/jimmy.js start


### PR DESCRIPTION
## Summary

`docker-compose up` で jinn をローカル起動できるようにする。

## 使い方

```bash
cp .env.example .env          # ANTHROPIC_API_KEY を設定
docker-compose up --build     # 初回ビルド＆起動
curl http://localhost:7777/api/status
```

## 構成

- **Dockerfile**: multi-stage build（builder: node:22、runner: node:22-slim + claude CLI）
- **docker-compose.yml**: ポート 7777・`./docker/data:/data`・`~/.claude:/root/.claude:ro`
- **docker/entrypoint.sh**: 初回自動初期化 + host を `0.0.0.0` に変更 + `jinn migrate` 自動実行

## 動作確認済み

`curl http://localhost:7777/api/status` → `{"status":"ok","uptime":5,"port":7777,...}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)