### PR TITLE
fix: useBreadcrumbs の無限ループを修正

### DIFF
--- a/packages/web/src/context/breadcrumb-context.tsx
+++ b/packages/web/src/context/breadcrumb-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, type ReactNode, useContext, useEffect, useState } from "react";
+import { createContext, type ReactNode, useContext, useEffect, useRef, useState } from "react";
 
 interface BreadcrumbItem {
   label: string;
@@ -32,13 +32,14 @@ export function BreadcrumbProvider({ children }: { children: ReactNode }) {
 
 export function useBreadcrumbs(items?: BreadcrumbItem[]) {
   const ctx = useContext(BreadcrumbContext);
-
-  // Serialize items for stable dependency comparison
-  const _itemsKey = items ? JSON.stringify(items) : "";
+  const { setItems } = ctx;
+  const itemsKey = items ? JSON.stringify(items) : "";
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
 
   useEffect(() => {
-    if (items) ctx.setItems(items);
-  }, [items, ctx.setItems]); // eslint-disable-line react-hooks/exhaustive-deps
+    if (itemsRef.current) setItems(itemsRef.current);
+  }, [itemsKey, setItems]);
 
   return ctx;
 }

--- a/packages/web/src/context/breadcrumb-context.tsx
+++ b/packages/web/src/context/breadcrumb-context.tsx
@@ -33,9 +33,10 @@ export function BreadcrumbProvider({ children }: { children: ReactNode }) {
 export function useBreadcrumbs(items?: BreadcrumbItem[]) {
   const ctx = useContext(BreadcrumbContext);
   const { setItems } = ctx;
+  // BreadcrumbItem has only string fields — JSON.stringify is always safe here
   const itemsKey = items ? JSON.stringify(items) : "";
   const itemsRef = useRef(items);
-  itemsRef.current = items;
+  itemsRef.current = items; // keep latest without triggering effect
 
   useEffect(() => {
     if (itemsRef.current) setItems(itemsRef.current);


### PR DESCRIPTION
## Summary

- `useBreadcrumbs` で `items` が毎レンダー新参照になることで `useEffect` が無限ループしていたバグを修正
- 計算済みの `itemsKey`（JSON文字列）を deps に使用し、`useRef` で最新値を保持
- `eslint-disable` コメントも不要になったため削除

## Test plan

- [x] `pnpm typecheck` エラーなし
- [x] `pnpm lint` エラーなし
- [x] ブラウザで http://localhost:3000 を開いて "Maximum update depth exceeded" エラーが消えることを確認

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)