### PR TITLE
chore: 対応エンジン・ランタイムを整理し Docker image に全 CLI を追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,11 @@ RUN pnpm build
 FROM node:22-slim AS runner
 WORKDIR /app
 
-# Install claude CLI
-RUN npm install -g @anthropic-ai/claude-code
+# Install AI engine CLIs
+RUN npm install -g \
+    @anthropic-ai/claude-code \
+    @openai/codex \
+    @google/gemini-cli
 
 # Copy build artifacts and dependencies
 COPY --from=builder /app/packages/jimmy/dist ./packages/jimmy/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,11 +16,11 @@ RUN pnpm build
 FROM node:22-slim AS runner
 WORKDIR /app
 
-# Install AI engine CLIs
+# Install AI engine CLIs (versions pinned for reproducible builds)
 RUN npm install -g \
-    @anthropic-ai/claude-code \
-    @openai/codex \
-    @google/gemini-cli
+    @anthropic-ai/claude-code@2.1.133 \
+    @openai/codex@0.129.0 \
+    @google/gemini-cli@0.41.2
 
 # Copy build artifacts and dependencies
 COPY --from=builder /app/packages/jimmy/dist ./packages/jimmy/dist

--- a/README.md
+++ b/README.md
@@ -145,8 +145,10 @@ gateway auto-restarts when you edit backend source files via Node's built-in
 `--watch` mode. To use a non-default gateway port, set `GATEWAY_PORT=<port>`
 before running `pnpm dev`.
 
-> **Prerequisites:** Node.js 22+, pnpm 10+, and the
-> [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) (`npm install -g @anthropic-ai/claude-code`).
+> **Prerequisites:** Node.js 22+, pnpm 10+, and at least one engine CLI:
+> - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) — `npm install -g @anthropic-ai/claude-code`
+> - [Codex CLI](https://github.com/openai/codex) — `npm install -g @openai/codex` *(optional)*
+> - [Gemini CLI](https://github.com/google-gemini/gemini-cli) — `npm install -g @google/gemini-cli` *(optional)*
 
 ### Available Scripts
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,8 @@ services:
       - ~/.claude:/home/gateway/.claude:ro
     environment:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      # Required if using codex engine:
+      # - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      # Required if using gemini engine:
+      # - GOOGLE_API_KEY=${GOOGLE_API_KEY:-}
     restart: unless-stopped

--- a/packages/jimmy/template/config.default.yaml
+++ b/packages/jimmy/template/config.default.yaml
@@ -15,6 +15,10 @@ engines:
     bin: codex
     model: gpt-5.4
     effortLevel: high
+  # gemini:
+  #   bin: gemini
+  #   model: gemini-2.5-pro
+  #   effortLevel: high
 
 connectors:
   slack:


### PR DESCRIPTION
## 概要

claude / codex / gemini の3エンジンが実装済みだが Docker image と設定テンプレートに不整合があったため整理。

## 変更内容

### Dockerfile
```dockerfile
# Before
RUN npm install -g @anthropic-ai/claude-code

# After
RUN npm install -g \
    @anthropic-ai/claude-code \
    @openai/codex \
    @google/gemini-cli
```

### config.default.yaml
gemini エンジンの設定例をコメントで追加:
```yaml
# gemini:
#   bin: gemini
#   model: gemini-2.5-pro
#   effortLevel: high
```

### README.md
必須（claude）・任意（codex / gemini）の CLI インストール手順を明記。

## 対応エンジン一覧

| エンジン | npm パッケージ | バイナリ |
|---------|-------------|--------|
| claude | `@anthropic-ai/claude-code` | `claude` |
| codex | `@openai/codex` | `codex` |
| gemini | `@google/gemini-cli` | `gemini` |

Closes #275